### PR TITLE
[k4simdelphes] add package recipe

### DIFF
--- a/packages/k4simdelphes/cmake2.patch
+++ b/packages/k4simdelphes/cmake2.patch
@@ -1,0 +1,18 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b94bd77..e0f564b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -27,13 +27,6 @@ endif()
+ 
+ message (STATUS "C++ standard: ${CMAKE_CXX_STANDARD}")
+ 
+-#--- add version files ---------------------------------------------------------
+-
+-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/K4SIMDELPHESVersion.h
+-               ${CMAKE_CURRENT_BINARY_DIR}/K4SIMDELPHESVersion.h )
+-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/K4SIMDELPHESVersion.h
+-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/k4simdelphes )
+-
+ # - Use GNU-style hierarchy for installing build products
+ include(GNUInstallDirs)
+

--- a/packages/k4simdelphes/package.py
+++ b/packages/k4simdelphes/package.py
@@ -1,0 +1,35 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
+
+
+class K4simdelphes(CMakePackage):
+    """EDM4HEP output for Delphes."""
+
+    homepage = "https://github.com/key4hep/k4SimDelphes"
+    git      = "https://github.com/key4hep/k4SimDelphes.git"
+    url      = "https://github.com/key4hep/k4SimDelphes/archive/v00-00-01.tar.gz"
+
+    maintainers = ['vvolkl']
+
+    version('main', branch='main')
+    k4_add_latest_commit_as_version(git)
+    version('0.0.1', sha256='4bc414ac72cd03638e7f406381b41814f6e19f3425051f094ac0b539630cd698')
+
+    patch('cmake2.patch', when="@0.0.1")
+
+    depends_on('edm4hep')
+    depends_on('delphes@3.4.3pre06:')
+    depends_on('pythia8')
+    depends_on('evtgen+pythia8')
+    depends_on('hepmc')
+
+    def setup_build_environment(self, env):
+        env.set('PYTHIA8', self.spec["pythia8"].prefix)
+
+    def url_for_version(self, version):
+       return ilc_url_for_version(self, version)

--- a/packages/key4hep-stack/package.py
+++ b/packages/key4hep-stack/package.py
@@ -50,6 +50,9 @@ class Key4hepStack(BundlePackage):
 
     depends_on("k4fwcore")
     k4_add_latest_commit_as_dependency("k4fwcore", "key4hep/k4fwcore", when="@master")
+
+    depends_on("k4simdelphes")
+    k4_add_latest_commit_as_dependency("k4simdelphes", "key4hep/k4simdelphes", when="@master")
     
     depends_on("guinea-pig")
     # todo: figure out the api for the cern gitlab instance


### PR DESCRIPTION
Adding a preliminary version to have `Delphes*_EDM4HEP` in the stack. The patch can be removed once the CMake configuration is final