### PR TITLE
Refactor using Key4hepPackage, IlcsoftPackage base classes

### DIFF
--- a/packages/Ilcsoftpackage/package.py
+++ b/packages/Ilcsoftpackage/package.py
@@ -17,6 +17,7 @@ import spack.user_environment as uenv
 import spack.store
 import os
 
+from spack.package import PackageBase
 
 
 
@@ -193,9 +194,18 @@ def ilc_url_for_version(self, version):
         return
     return url
 
-class Ilcsoftpackage(Package):
+class Key4hepPackage(PackageBase):
+
+    tags = ['hep', 'key4hep']
+
+class Ilcsoftpackage(Key4hepPackage):
     """This class needs to be present to allow spack to import this file.
     the above function could also be a member here, but there is an
     issue with the logging of packages that use custom base classes.
     """
-    pass
+
+
+    
+    def url_for_version(self, version):
+        return ilc_url_for_version(self, version)
+

--- a/packages/aidatt/package.py
+++ b/packages/aidatt/package.py
@@ -4,10 +4,11 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage 
 from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
 
 
-class Aidatt(CMakePackage):
+class Aidatt(CMakePackage, Ilcsoftpackage):
     """Tracking toolkit developed in the AIDA project."""
 
     homepage = "https://github.com/AIDASoft/aidaTT"
@@ -25,6 +26,3 @@ class Aidatt(CMakePackage):
     depends_on('generalbrokenlines')
     depends_on('dd4hep')
     depends_on('lcio')
-
-    def url_for_version(self, version):
-        return ilc_url_for_version(self, version)

--- a/packages/ced/package.py
+++ b/packages/ced/package.py
@@ -5,10 +5,10 @@
 
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
-class Ced(CMakePackage):
+class Ced(CMakePackage, Ilcsoftpackage):
     """CED is a server client application for OpenGL drawing"""
 
     homepage = "https://github.com/iLCSoft/CED"
@@ -39,7 +39,3 @@ class Ced(CMakePackage):
         #args = [self.define("BUILD_TESTING", self.run_tests)]
         args = []
         return args
-
-    def url_for_version(self, version):
-       return ilc_url_for_version(self, version)
-

--- a/packages/cedviewer/package.py
+++ b/packages/cedviewer/package.py
@@ -5,10 +5,10 @@
 
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
-class Cedviewer(CMakePackage):
+class Cedviewer(CMakePackage, Ilcsoftpackage):
     """CEDViewer processor for the CED event display."""
 
     url      = "https://github.com/iLCSoft/CEDViewer/archive/v01-17-01.tar.gz"
@@ -30,6 +30,3 @@ class Cedviewer(CMakePackage):
 
     def setup_run_environment(self, spack_env):
         spack_env.prepend_path('MARLIN_DLL', self.prefix.lib + "/libCEDViewer.so")
-
-    def url_for_version(self, version):
-       return ilc_url_for_version(self, version)

--- a/packages/cepcsw/package.py
+++ b/packages/cepcsw/package.py
@@ -1,10 +1,10 @@
 # ----------------------------------------------------------------------------
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import k4_add_latest_commit_as_version 
+from spack.pkg.k4.Ilcsoftpackage import Key4hepPackage, k4_add_latest_commit_as_version 
 
 
-class Cepcsw(CMakePackage):
+class Cepcsw(CMakePackage, Key4hepPackage):
     """CEPC offline experiment software based on Key4hep."""
 
     homepage = "https://github.com/cepc/CEPCSW"

--- a/packages/clicperformance/package.py
+++ b/packages/clicperformance/package.py
@@ -4,10 +4,10 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
-class Clicperformance(CMakePackage):
+class Clicperformance(CMakePackage, Ilcsoftpackage):
     """ Package containing processors and configurations to determine the performance of the CLIC detector model"""
 
     url      = "https://github.com/iLCSoft/ClicPerformance/archive/v02-04.tar.gz"
@@ -33,6 +33,3 @@ class Clicperformance(CMakePackage):
 
     def setup_run_environment(self, spack_env):
         spack_env.prepend_path('MARLIN_DLL', self.prefix.lib + "/libClicPerformance.so")
-
-    def url_for_version(self, version):
-       return ilc_url_for_version(self, version)

--- a/packages/clupatra/package.py
+++ b/packages/clupatra/package.py
@@ -5,10 +5,10 @@
 
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
-class Clupatra(CMakePackage):
+class Clupatra(CMakePackage, Ilcsoftpackage):
     """Topological pattern recognition (for the TPC)"""
 
     url      = "https://github.com/iLCSoft/Clupatra/archive/v01-03.tar.gz"
@@ -33,6 +33,3 @@ class Clupatra(CMakePackage):
 
     def setup_run_environment(self, spack_env):
         spack_env.prepend_path('MARLIN_DLL', self.prefix.lib + "/libClupatra.so")
-
-    def url_for_version(self, version):
-       return ilc_url_for_version(self, version)

--- a/packages/conddbmysql/package.py
+++ b/packages/conddbmysql/package.py
@@ -4,10 +4,10 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import k4_add_latest_commit_as_version
+from spack.pkg.k4.Ilcsoftpackage import Key4hepPackage, k4_add_latest_commit_as_version
 
 
-class Conddbmysql(CMakePackage):
+class Conddbmysql(CMakePackage, Key4hepPackage):
     """ Linear Collider MySQL Conditions Database """
 
     homepage = "https://github.com/iLCSoft/conddbmysql"

--- a/packages/conformaltracking/package.py
+++ b/packages/conformaltracking/package.py
@@ -5,10 +5,10 @@
 
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
-class Conformaltracking(CMakePackage):
+class Conformaltracking(CMakePackage, Ilcsoftpackage):
     """Package for running pattern recognition based on conformal mapping
        and cellular automaton. This is not tied to a given geometry, but
        has been developed for the CLIC detector model 2015."""
@@ -42,6 +42,3 @@ class Conformaltracking(CMakePackage):
 
     def setup_run_environment(self, spack_env):
         spack_env.prepend_path('MARLIN_DLL', self.prefix.lib + "/libConformalTracking.so")
-
-    def url_for_version(self, version):
-       return ilc_url_for_version(self, version)

--- a/packages/ddkaltest/package.py
+++ b/packages/ddkaltest/package.py
@@ -5,10 +5,10 @@
 
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
-class Ddkaltest(CMakePackage):
+class Ddkaltest(CMakePackage, Ilcsoftpackage):
     """Interface between KalTest fitter and DD4hep based geometry"""
 
     homepage = "https://github.com/iLCSoft/DDKalTest"
@@ -39,6 +39,3 @@ class Ddkaltest(CMakePackage):
     def installheaders(self):
       #make('install')
       install_tree('.', self.prefix)
-    
-    def url_for_version(self, version):
-       return ilc_url_for_version(self, version)

--- a/packages/ddmarlinpandora/package.py
+++ b/packages/ddmarlinpandora/package.py
@@ -4,10 +4,10 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
-class Ddmarlinpandora(CMakePackage):
+class Ddmarlinpandora(CMakePackage, Ilcsoftpackage):
     """Interface between Marlin and PandoraPFA."""
 
     url      = "https://github.com/iLCSoft/DDMarlinPandora/archive/v00-11.tar.gz"
@@ -32,7 +32,3 @@ class Ddmarlinpandora(CMakePackage):
 
     def setup_run_environment(self, spack_env):
         spack_env.prepend_path('MARLIN_DLL', self.prefix.lib + "/libDDMarlinPandora.so")
-
-
-    def url_for_version(self, version):
-       return ilc_url_for_version(self, version)

--- a/packages/dual-readout/package.py
+++ b/packages/dual-readout/package.py
@@ -5,10 +5,10 @@
 
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import k4_add_latest_commit_as_version
+from spack.pkg.k4.Ilcsoftpackage import Key4hepPackage, k4_add_latest_commit_as_version
 
 
-class DualReadout(CMakePackage):
+class DualReadout(CMakePackage, Key4hepPackage):
     """Repository for GEANT4 simulation & analysis of the dual-readout calorimeter """
 
     url      = "https://github.com/HEP-FCC/dual-readout/archive/v0.0.2.tar.gz"

--- a/packages/edm4hep/package.py
+++ b/packages/edm4hep/package.py
@@ -1,9 +1,9 @@
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import k4_add_latest_commit_as_version
+from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
-class Edm4hep(CMakePackage):
+class Edm4hep(CMakePackage, Ilcsoftpackage):
     """Event data model of Key4HEP"""
 
     homepage = "https://github.com/key4hep/EDM4hep"
@@ -68,15 +68,3 @@ class Edm4hep(CMakePackage):
         return args
 
 
-    def url_for_version(self, version):
-        # releases are dashed and padded with a leading zero
-        # the patch version is omitted when 0
-        # so for example v01-12-01, v01-12 ...
-        major = (str(version[0]).zfill(2))
-        minor = (str(version[1]).zfill(2))
-        patch = (str(version[2]).zfill(2))
-        if version[2] == 0:
-            url = "https://github.com/key4hep/edm4hep/archive/v%s-%s.tar.gz" % (major, minor)
-        else:
-            url = "https://github.com/key4hep/edm4hep/archive/v%s-%s-%s.tar.gz" % (major, minor, patch)
-        return url

--- a/packages/fcalclusterer/package.py
+++ b/packages/fcalclusterer/package.py
@@ -4,10 +4,10 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
-class Fcalclusterer(CMakePackage):
+class Fcalclusterer(CMakePackage, Ilcsoftpackage):
     """Reconstruction for the Forward Calorimeters of Future e+e- colliders."""
 
     url      = "https://github.com/FCalSW/FCalClusterer/archive/v01-00-01.tar.gz"
@@ -49,6 +49,3 @@ class Fcalclusterer(CMakePackage):
 
     def setup_run_environment(self, spack_env):
         spack_env.prepend_path('MARLIN_DLL', self.prefix.lib + "/libFCalClusterer.so")
-
-    def url_for_version(self, version):
-       return ilc_url_for_version(self, version)

--- a/packages/fcc-edm/package.py
+++ b/packages/fcc-edm/package.py
@@ -1,8 +1,8 @@
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import k4_add_latest_commit_as_version 
+from spack.pkg.k4.Ilcsoftpackage import Key4hepPackage, k4_add_latest_commit_as_version 
 
-class FccEdm(CMakePackage):
+class FccEdm(CMakePackage, Key4hepPackage):
     """Event data model of FCC"""
 
     homepage = "https://github.com/HEP-FCC/fcc-edm"

--- a/packages/fccsw/package.py
+++ b/packages/fccsw/package.py
@@ -1,8 +1,8 @@
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import k4_add_latest_commit_as_version 
+from spack.pkg.k4.Ilcsoftpackage import Key4hepPackage, k4_add_latest_commit_as_version 
 
-class Fccsw(CMakePackage):
+class Fccsw(CMakePackage, Key4hepPackage):
     """Software framework of the FCC project"""
     homepage = "https://github.com/HEP-FCC/FCCSW/"
     url      = "https://github.com/HEP-FCC/FCCSW/archive/v0.16.tar.gz"

--- a/packages/forwardtracking/package.py
+++ b/packages/forwardtracking/package.py
@@ -4,10 +4,10 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
-class Forwardtracking(CMakePackage):
+class Forwardtracking(CMakePackage, Ilcsoftpackage):
     """Track Reconstruction for the Forward Direction (for the FTD)"""
 
     url      = "https://github.com/iLCSoft/ForwardTracking/archive/v01-14.tar.gz"
@@ -42,6 +42,3 @@ class Forwardtracking(CMakePackage):
 
     def setup_run_environment(self, spack_env):
         spack_env.prepend_path('MARLIN_DLL', self.prefix.lib + "/libForwardTracking.so")
-
-    def url_for_version(self, version):
-       return ilc_url_for_version(self, version)

--- a/packages/garlic/package.py
+++ b/packages/garlic/package.py
@@ -5,10 +5,10 @@
 
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
-class Garlic(CMakePackage):
+class Garlic(CMakePackage, Ilcsoftpackage):
     """Garlic is a Marlin Processor to identify photons and electrons."""
 
     url      = "https://github.com/iLCSoft/Garlic/archive/v03-01.tar.gz"
@@ -28,6 +28,3 @@ class Garlic(CMakePackage):
 
     def setup_run_environment(self, spack_env):
         spack_env.prepend_path('MARLIN_DLL', self.prefix.lib + "/libGarlic.so")
-
-    def url_for_version(self, version):
-       return ilc_url_for_version(self, version)

--- a/packages/gear/package.py
+++ b/packages/gear/package.py
@@ -4,10 +4,10 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
-class Gear(CMakePackage):
+class Gear(CMakePackage, Ilcsoftpackage):
     """ Linear Collider Conditions Data toolkit."""
 
     homepage = "https://github.com/iLCSoft/gear"
@@ -45,6 +45,3 @@ class Gear(CMakePackage):
         args.append(self.define_from_variant('INSTALL_DOC', 'doc'))
         args.append('-DCMAKE_CXX_STANDARD=17')
         return args
-
-    def url_for_version(self, version):
-       return ilc_url_for_version(self, version)

--- a/packages/generalbrokenlines/package.py
+++ b/packages/generalbrokenlines/package.py
@@ -15,6 +15,8 @@ class Generalbrokenlines(CMakePackage):
     url      = "https://github.com/GeneralBrokenLines/GeneralBrokenLines/archive/V02-02-00.tar.gz"
     git      = "https://github.com/GeneralBrokenLines/GeneralBrokenLines.git"
 
+    tags = ['hep']
+
     maintainers = ['vvolkl']
 
     version('master', branch='master')

--- a/packages/guinea-pig/package.py
+++ b/packages/guinea-pig/package.py
@@ -14,6 +14,8 @@ class GuineaPig(CMakePackage):
     url      = "https://gitlab.cern.ch/clic-software/guinea-pig/-/archive/v1.2.2rc/guinea-pig-v1.2.2rc.zip"
     git = "https://gitlab.cern.ch/clic-software/guinea-pig.git"
 
+    tags = ['hep']
+
     version('master', branch='master')
     version('1.2.2rc', 'fec0d1b6aa72523eec4e7c71bca2c1ff', )
 

--- a/packages/ilcutil/package.py
+++ b/packages/ilcutil/package.py
@@ -4,10 +4,10 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
-class Ilcutil(CMakePackage):
+class Ilcutil(CMakePackage, Ilcsoftpackage):
     """ A utility package for the iLCSoft software framework """
 
     homepage = "https://github.com/iLCSoft/ilcutil"
@@ -21,6 +21,3 @@ class Ilcutil(CMakePackage):
     version('1.6', sha256='09083890721704f39a3e902dc660db5326027cc38446b813233d04ec3233ba2e')
 
     patch("installdoc.patch")
-
-    def url_for_version(self, version):
-       return ilc_url_for_version(self, version)

--- a/packages/ildperformance/package.py
+++ b/packages/ildperformance/package.py
@@ -4,10 +4,10 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
-class Ildperformance(CMakePackage):
+class Ildperformance(CMakePackage, Ilcsoftpackage):
     """Assembly of various Marlin processor for reconstruction."""
 
     url      = "https://github.com/iLCSoft/ILDPerformance/archive/v01-08.tar.gz"
@@ -33,6 +33,3 @@ class Ildperformance(CMakePackage):
 
     def setup_run_environment(self, spack_env):
         spack_env.prepend_path('MARLIN_DLL', self.prefix.lib + "/libILDPerformance.so")
-
-    def url_for_version(self, version):
-       return ilc_url_for_version(self, version)

--- a/packages/k4fwcore/package.py
+++ b/packages/k4fwcore/package.py
@@ -1,7 +1,8 @@
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import k4_add_latest_commit_as_version
+from spack.pkg.k4.Ilcsoftpackage import Key4hepPackage, k4_add_latest_commit_as_version,  ilc_url_for_version
 
-class K4fwcore(CMakePackage):
+
+class K4fwcore(CMakePackage, Key4hepPackage):
     """Core framework components of the Key4HEP project"""
     homepage = "https://github.com/key4hep/k4FWCore"
     url = "https://github.com/key4hep/k4FWCore/archive/v00-01.tar.gz"
@@ -42,17 +43,8 @@ class K4fwcore(CMakePackage):
         return args
 
     def url_for_version(self, version):
-        # releases are dashes and padded with a leading zero
-        # the patch version is omitted when 0
-        # so for example v01-12-01, v01-12 ...
-        major = (str(version[0]).zfill(2))
-        minor = (str(version[1]).zfill(2))
-        patch = (str(version[2]).zfill(2))
-        if version[2] == 0:
-            url = "https://github.com/key4hep/k4FWCore/archive/v%s-%s.tar.gz" % (major, minor)
-        else:
-            url = "https://github.com/key4hep/k4FWCore/archive/v%s-%s-%s.tar.gz" % (major, minor, patch)
-        return url
+        return ilc_url_for_version(self, version)
+
     
     def setup_run_environment(self, spack_env):
         spack_env.prepend_path('PYTHONPATH', self.prefix.python)

--- a/packages/k4marlinwrapper/package.py
+++ b/packages/k4marlinwrapper/package.py
@@ -4,9 +4,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
 
-class K4marlinwrapper(CMakePackage):
+class K4marlinwrapper(CMakePackage, Ilcsoftpackage):
     """Gaudify Marlin Processors in order to run them in the Key4HEP framework"""
 
     homepage = "https://github.com/key4hep/k4MarlinWrapper"
@@ -38,6 +38,3 @@ class K4marlinwrapper(CMakePackage):
         spack_env.prepend_path('PYTHONPATH', self.prefix.python)
         spack_env.prepend_path("PATH", self.prefix.scripts)
         spack_env.set("K4MARLINWRAPPER", self.prefix.share.k4MarlinWrapper)
-
-    def url_for_version(self, version):
-       return ilc_url_for_version(self, version)

--- a/packages/kaldet/package.py
+++ b/packages/kaldet/package.py
@@ -5,10 +5,10 @@
 
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
-class Kaldet(CMakePackage):
+class Kaldet(CMakePackage, Ilcsoftpackage):
     """Kaldet: part of ilcsoft tracking."""
 
     homepage = "https://github.com/iLCSoft/KalDet"
@@ -43,6 +43,3 @@ class Kaldet(CMakePackage):
 
     def setup_run_environment(self, spack_env):
         spack_env.prepend_path('CPATH', self.prefix.include.kaldet)
-
-    def url_for_version(self, version):
-       return ilc_url_for_version(self, version)

--- a/packages/kaltest/package.py
+++ b/packages/kaltest/package.py
@@ -5,10 +5,10 @@
 
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
-class Kaltest(CMakePackage):
+class Kaltest(CMakePackage, Ilcsoftpackage):
     """ Kaltest tracking software. """
 
     homepage = "https://github.com/iLCSoft/KalTest"

--- a/packages/key4hep-stack/package.py
+++ b/packages/key4hep-stack/package.py
@@ -8,9 +8,10 @@ import llnl.util.tty as tty
 import spack.user_environment as uenv
 from spack.pkg.k4.Ilcsoftpackage import k4_add_latest_commit_as_dependency 
 from spack.pkg.k4.Ilcsoftpackage import k4_generate_setup_script 
+from spack.pkg.k4.Ilcsoftpackage import Key4hepPackage
 
 
-class Key4hepStack(BundlePackage):
+class Key4hepStack(BundlePackage, Key4hepPackage):
     """Bundle package to install the Key4hep software stack."""
     
     homepage = 'https://cern.ch/key4hep'

--- a/packages/kitrack/package.py
+++ b/packages/kitrack/package.py
@@ -5,10 +5,10 @@
 
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
-class Kitrack(CMakePackage):
+class Kitrack(CMakePackage, Ilcsoftpackage):
     """Toolkit for Tracking. Consists of KiTrack (Cellular Automaton, a Hopfield Neural Network, the hit and track classes) and Criteria (the criteria classes)."""
 
     url      = "https://github.com/iLCSoft/KiTrack/archive/v01-10.tar.gz"
@@ -30,7 +30,4 @@ class Kitrack(CMakePackage):
         args.append('-DCMAKE_CXX_STANDARD=%s'
                     % self.spec['root'].variants['cxxstd'].value)
         return args
-
-    def url_for_version(self, version):
-       return ilc_url_for_version(self, version)
 

--- a/packages/kitrackmarlin/package.py
+++ b/packages/kitrackmarlin/package.py
@@ -5,10 +5,10 @@
 
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
-class Kitrackmarlin(CMakePackage):
+class Kitrackmarlin(CMakePackage, Ilcsoftpackage):
     """Implementation of classes for the use of KiTrack by Marlin"""
 
     url      = "https://github.com/iLCSoft/KiTrackMarlin/archive/v01-13.tar.gz"
@@ -28,6 +28,3 @@ class Kitrackmarlin(CMakePackage):
     depends_on('gsl')
     depends_on('dd4hep')
     depends_on('clhep')
-
-    def url_for_version(self, version):
-       return ilc_url_for_version(self, version)

--- a/packages/larcontent/package.py
+++ b/packages/larcontent/package.py
@@ -15,6 +15,8 @@ class Larcontent(CMakePackage):
     homepage  = "https://github.com/PandoraPFA/larcontent"
     git      = "https://github.com/PandoraPFA/larcontent.git"
 
+    tags = ['hep']
+
     maintainers = ['vvolkl']
 
     version('master', branch='master')

--- a/packages/lccd/package.py
+++ b/packages/lccd/package.py
@@ -4,10 +4,10 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
-class Lccd(CMakePackage):
+class Lccd(CMakePackage, Ilcsoftpackage):
     """ Linear Collider Conditions Data toolkit."""
 
     homepage = "https://github.com/iLCSoft/lccd"
@@ -34,7 +34,3 @@ class Lccd(CMakePackage):
         # todo: add variant
         args.append(self.define_from_variant('LCCD_CONDDBMYSQL', 'conddbmysql'))
         return args
-
-    def url_for_version(self, version):
-       return ilc_url_for_version(self, version)
-

--- a/packages/lccontent/package.py
+++ b/packages/lccontent/package.py
@@ -15,6 +15,8 @@ class Lccontent(CMakePackage):
     homepage  = "https://github.com/PandoraPFA/lccontent"
     git      = "https://github.com/PandoraPFA/lccontent.git"
 
+    tags = ['hep']
+
     maintainers = ['vvolkl']
 
     version('master', branch='master')

--- a/packages/lcfiplus/package.py
+++ b/packages/lcfiplus/package.py
@@ -5,10 +5,10 @@
 
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
-class Lcfiplus(CMakePackage):
+class Lcfiplus(CMakePackage, Ilcsoftpackage):
     """Flavor tagging code for ILC detectors, for documentation consult confluence at https://confluence.slac.stanford.edu/display/ilc/LCFIPlus"""
 
     url      = "https://github.com/lcfiplus/LCFIPlus/archive/v00-10.tar.gz"
@@ -40,6 +40,3 @@ class Lcfiplus(CMakePackage):
 
     def setup_run_environment(self, spack_env):
         spack_env.prepend_path('MARLIN_DLL', self.prefix.lib + "/libLCFIPlus.so")
-
-    def url_for_version(self, version):
-        return ilc_url_for_version(self, version)

--- a/packages/lcfivertex/package.py
+++ b/packages/lcfivertex/package.py
@@ -4,10 +4,10 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
-class Lcfivertex(CMakePackage):
+class Lcfivertex(CMakePackage, Ilcsoftpackage):
     """Package for vertex finding as well as vertex charge determination in b- and c-jets."""
 
     url      = "https://github.com/iLCSoft/LCFIVertex/archive/v00-08.tar.gz"
@@ -32,6 +32,3 @@ class Lcfivertex(CMakePackage):
     def cmake_args(self):
         args = [self.define('INSTALL_DOC', False)]
         return args
-
-    def url_for_version(self, version):
-       return ilc_url_for_version(self, version)

--- a/packages/lcgeo/package.py
+++ b/packages/lcgeo/package.py
@@ -4,10 +4,10 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
-class Lcgeo(CMakePackage):
+class Lcgeo(CMakePackage, Ilcsoftpackage):
     """DD4hep geometry models for future colliders."""
 
     homepage = "https://github.com/iLCSoft/lcgeo"
@@ -53,6 +53,3 @@ class Lcgeo(CMakePackage):
     def setup_run_environment(self, env):
         env.set('LCGEO', self.prefix.share.lcgeo.compact)
         env.set('lcgeo_DIR', self.prefix)
-
-    def url_for_version(self, version):
-       return ilc_url_for_version(self, version)

--- a/packages/lctuple/package.py
+++ b/packages/lctuple/package.py
@@ -4,10 +4,10 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
-class Lctuple(CMakePackage):
+class Lctuple(CMakePackage, Ilcsoftpackage):
     """Marlin package that creates a ROOT TTree with a column wise ntuple from LCIO collections."""
 
     url      = "https://github.com/iLCSoft/LCTuple/archive/v01-12.tar.gz"
@@ -35,6 +35,3 @@ class Lctuple(CMakePackage):
                     % self.spec['root'].variants['cxxstd'].value)
         args.append('-DBUILD_TESTING=%s' % self.run_tests)
         return args
-
-    def url_for_version(self, version):
-       return ilc_url_for_version(self, version)

--- a/packages/lich/package.py
+++ b/packages/lich/package.py
@@ -15,6 +15,8 @@ class Lich(CMakePackage):
     homepage = "https://github.com/danerdaner/LICH"
     git      = "https://github.com/danerdaner/LICH.git"
 
+    tags = ['hep']
+
     maintainers = ['vvolkl']
 
     version('master', branch='master')

--- a/packages/marlin/package.py
+++ b/packages/marlin/package.py
@@ -4,10 +4,10 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
-class Marlin(CMakePackage):
+class Marlin(CMakePackage, Ilcsoftpackage):
     """ Linear Collider framework"""
 
     homepage = "https://github.com/iLCSoft/marlin"
@@ -59,6 +59,3 @@ class Marlin(CMakePackage):
         if 'aida' in self.spec:
           args.append('-DAIDA_DIR=%s' % self.spec["aida"].prefix)
         return args
-
-    def url_for_version(self, version):
-       return ilc_url_for_version(self, version)

--- a/packages/marlindd4hep/package.py
+++ b/packages/marlindd4hep/package.py
@@ -5,10 +5,10 @@
 
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
-class Marlindd4hep(CMakePackage):
+class Marlindd4hep(CMakePackage, Ilcsoftpackage):
     """Provides one processor to initialize a DD4hep detector geometry from a compact file for a Marlin job."""
 
     url      = "https://github.com/iLCSoft/MarlinDD4hep/archive/v00-06.tar.gz"
@@ -33,6 +33,3 @@ class Marlindd4hep(CMakePackage):
 
     def setup_run_environment(self, spack_env):
         spack_env.prepend_path('MARLIN_DLL', self.prefix.lib + "/libMarlinDD4hep.so")
-
-    def url_for_version(self, version):
-       return ilc_url_for_version(self, version)

--- a/packages/marlinfastjet/package.py
+++ b/packages/marlinfastjet/package.py
@@ -4,10 +4,10 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
-class Marlinfastjet(CMakePackage):
+class Marlinfastjet(CMakePackage, Ilcsoftpackage):
     """Marlin processor to interface FastJet."""
 
     url      = "https://github.com/iLCSoft/MarlinFastjet/archive/v00-05-02.tar.gz"
@@ -38,6 +38,3 @@ class Marlinfastjet(CMakePackage):
 
     def setup_run_environment(self, spack_env):
         spack_env.prepend_path('MARLIN_DLL', self.prefix.lib + "/libMarlinFastJet.so")
-
-    def url_for_version(self, version):
-       return ilc_url_for_version(self, version)

--- a/packages/marlinkinfit/package.py
+++ b/packages/marlinkinfit/package.py
@@ -4,10 +4,10 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
-class Marlinkinfit(CMakePackage):
+class Marlinkinfit(CMakePackage, Ilcsoftpackage):
     """Kinematic Fitting Library for Marlin"""
 
     url      = "https://github.com/iLCSoft/MarlinKinfit/archive/v00-06.tar.gz"
@@ -37,6 +37,3 @@ class Marlinkinfit(CMakePackage):
 
     def setup_run_environment(self, spack_env):
         spack_env.prepend_path('MARLIN_DLL', self.prefix.lib + "/libMarlinKinfit.so")
-
-    def url_for_version(self, version):
-       return ilc_url_for_version(self, version)

--- a/packages/marlinpandora/package.py
+++ b/packages/marlinpandora/package.py
@@ -4,15 +4,16 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
-class Marlinpandora(CMakePackage):
+class Marlinpandora(CMakePackage, Ilcsoftpackage):
     """Assembly of various Marlin processor for reconstruction."""
 
     url      = "https://github.com/PandoraPFA/MarlinPandora/archive/v03-00-01.tar.gz"
     homepage = "https://github.com/PandoraPFA/MarlinPandora"
     git      = "https://github.com/PandoraPFA/MarlinPandora.git"
+
 
     maintainers = ['vvolkl']
 
@@ -30,6 +31,3 @@ class Marlinpandora(CMakePackage):
 
     def setup_run_environment(self, spack_env):
         spack_env.prepend_path('MARLIN_DLL', self.prefix.lib + "/libMarlinPandora.so")
-
-    def url_for_version(self, version):
-       return ilc_url_for_version(self, version)

--- a/packages/marlinreco/package.py
+++ b/packages/marlinreco/package.py
@@ -4,10 +4,10 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
-class Marlinreco(CMakePackage):
+class Marlinreco(CMakePackage, Ilcsoftpackage):
     """Assembly of various Marlin processor for reconstruction."""
 
     url      = "https://github.com/iLCSoft/MarlinReco/archive/v01-27.tar.gz"
@@ -33,6 +33,3 @@ class Marlinreco(CMakePackage):
 
     def setup_run_environment(self, spack_env):
         spack_env.prepend_path('MARLIN_DLL', self.prefix.lib + "/libMarlinReco.so")
-
-    def url_for_version(self, version):
-       return ilc_url_for_version(self, version)

--- a/packages/marlintrkprocessors/package.py
+++ b/packages/marlintrkprocessors/package.py
@@ -5,10 +5,10 @@
 
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
-class Marlintrkprocessors(CMakePackage):
+class Marlintrkprocessors(CMakePackage, Ilcsoftpackage):
     """A collection of Tracking Relelated Processors Based on MarlinTrk"""
 
     url      = "https://github.com/iLCSoft/MarlinTrkProcessors/archive/v02-11.tar.gz"
@@ -34,6 +34,3 @@ class Marlintrkprocessors(CMakePackage):
 
     def setup_run_environment(self, spack_env):
         spack_env.prepend_path('MARLIN_DLL', self.prefix.lib + "/libMarlinTrkProcessors.so")
-
-    def url_for_version(self, version):
-       return ilc_url_for_version(self, version)

--- a/packages/marlinutil/package.py
+++ b/packages/marlinutil/package.py
@@ -5,10 +5,10 @@
 
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
-class Marlinutil(CMakePackage):
+class Marlinutil(CMakePackage, Ilcsoftpackage):
     """ Library that containes classes and functions that are used by more
     than one processor. In particular it contains the geometry classes that
     are used until we have the geometry for reconstruction package (GEAR)."""
@@ -30,6 +30,3 @@ class Marlinutil(CMakePackage):
     depends_on('ced')
     depends_on('dd4hep')
     depends_on('root')
-
-    def url_for_version(self, version):
-       return ilc_url_for_version(self, version)

--- a/packages/overlay/package.py
+++ b/packages/overlay/package.py
@@ -4,10 +4,10 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
-class Overlay(CMakePackage):
+class Overlay(CMakePackage, Ilcsoftpackage):
     """The package Overlay provides code for event overlay with Marlin."""
 
     url      = "https://github.com/iLCSoft/Overlay/archive/v00-22.tar.gz"
@@ -38,6 +38,3 @@ class Overlay(CMakePackage):
 
     def setup_run_environment(self, spack_env):
         spack_env.prepend_path('MARLIN_DLL', self.prefix.lib + "/libOverlay.so")
-
-    def url_for_version(self, version):
-       return ilc_url_for_version(self, version)

--- a/packages/pandoraanalysis/package.py
+++ b/packages/pandoraanalysis/package.py
@@ -14,6 +14,8 @@ class Pandoraanalysis(CMakePackage):
     homepage = "https://github.com/PandoraPFA/LCPandoraAnalysis"
     git      = "https://github.com/PandoraPFA/LCPandoraAnalysis.git"
 
+    tags = ['hep']
+
     maintainers = ['vvolkl']
 
     version('master', branch='master')

--- a/packages/pandorapfa/package.py
+++ b/packages/pandorapfa/package.py
@@ -17,6 +17,8 @@ class Pandorapfa(Package):
     homepage  = "https://github.com/PandoraPFA/PandoraPFA"
     git      = "https://github.com/PandoraPFA/PandoraPFA.git"
 
+    tags = ['hep']
+
     maintainers = ['vvolkl']
 
     version('master', branch='master')

--- a/packages/pandorasdk/package.py
+++ b/packages/pandorasdk/package.py
@@ -17,6 +17,8 @@ class Pandorasdk(CMakePackage):
     homepage  = "https://github.com/PandoraPFA/PandoraSDK"
     git      = "https://github.com/PandoraPFA/PandoraSDK.git"
 
+    tags = ['hep']
+
     maintainers = ['vvolkl']
 
     version('master', branch='master')

--- a/packages/physsim/package.py
+++ b/packages/physsim/package.py
@@ -16,6 +16,8 @@ class Physsim(CMakePackage):
 
     maintainers = ['vvolkl']
 
+    tags = ['hep']
+
     version('master', branch='master')
     k4_add_latest_commit_as_version(git)
     version('0.4.1', sha256='4c22eee5dcccb764a5ff90850aeb33563c45a14af8939a3ebea736c7d92ac1c1')

--- a/packages/raida/package.py
+++ b/packages/raida/package.py
@@ -4,10 +4,10 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
-class Raida(CMakePackage):
+class Raida(CMakePackage, Ilcsoftpackage):
     """ A utility package for the iLCSoft software framework """
 
     homepage = "https://github.com/iLCSoft/raida"
@@ -31,6 +31,3 @@ class Raida(CMakePackage):
                     % self.spec['root'].variants['cxxstd'].value)
         args.append('-DBUILD_TESTING=%s' % self.run_tests)
         return args
-
-    def url_for_version(self, version):
-       return ilc_url_for_version(self, version)

--- a/packages/tricktrack/package.py
+++ b/packages/tricktrack/package.py
@@ -10,6 +10,8 @@ class Tricktrack(CMakePackage):
     url      = "https://github.com/HSF/TrickTrack/archive/v1.0.8.tar.gz"
     git      = "https://github.com/HSF/TrickTrack.git"
 
+    tags = ['hep']
+
     version('master', branch='master')
     k4_add_latest_commit_as_version(git)
     version('1.0.9', sha256='988cedbb28ec8f5cc95b762aa8a38e36d75cfc47bd009c9dc4ef365e9751b80d')


### PR DESCRIPTION
Right now Key4hepPackage only applies the labels `"hep"` and `'key4hep'` and Ilcsoftpackage deals with the version convention. But this can then be used to change other things that apply to all packages, p.ex. change the default generator from make to ninja.