### PR TITLE
Update k4LCIOReader to v0.2.0

### DIFF
--- a/packages/k4lcioreader/package.py
+++ b/packages/k4lcioreader/package.py
@@ -13,6 +13,7 @@ class K4lcioreader(CMakePackage, Key4hepPackage):
     version('master', branch='master')
     k4_add_latest_commit_as_version(git)
     version('0.1.0', sha256='996d1ff78c0a8a2f7f358dd4ea19f955853ad0902ee86b99c484de58c5fc2e2c')
+    version('0.2.0', sha256='346fc2ba4b4175895597e093f566ba6407be9eeb9cde0766304e0f19ad03e081')
 
     variant('cxxstd',
             default='17',
@@ -24,6 +25,7 @@ class K4lcioreader(CMakePackage, Key4hepPackage):
     depends_on('lcio')
     depends_on('podio@0.12:')
     depends_on('edm4hep')
+    depends_on('k4fwcore')
 
     def cmake_args(self):
         args = []

--- a/packages/k4lcioreader/package.py
+++ b/packages/k4lcioreader/package.py
@@ -25,7 +25,7 @@ class K4lcioreader(CMakePackage, Key4hepPackage):
     depends_on('lcio')
     depends_on('podio@0.12:')
     depends_on('edm4hep')
-    depends_on('k4fwcore')
+    depends_on('k4fwcore@0.2.0')
 
     def cmake_args(self):
         args = []


### PR DESCRIPTION
The Gaudi Algorithm LCIOInput is merged into this project, so need to depend on k4FWCore.