### PR TITLE
dd4hep: enable hepmc3 support

### DIFF
--- a/config/packages.yaml
+++ b/config/packages.yaml
@@ -15,7 +15,7 @@ packages:
   boost:
     variants: +python
   dd4hep:
-    variants: +geant4+lcio
+    variants: +geant4+lcio+hepmc3
   xercesc:
     variants: cxxstd=11
   root:


### PR DESCRIPTION
DD4hep: Enable the HepMC3 input reader for ddsim.
