### PR TITLE
Use release branch for deployment of spack

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,6 +16,7 @@ setup_spack_push:
     tags:
         - k4-build-spack-nightlies
     only:
+        - release
       refs:
           - pushes
           - merge_requests


### PR DESCRIPTION
This will change the gitlab ci to use the `release` branch of `key4hep-spack`  to deploy spack, in order to have more stability.