### PR TITLE
[ci] use --no-checksum to install nightlies to work with new com…

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,7 +59,7 @@ build-spack-nightlies:
         - cp ${PWD}/spack/var/spack/repos/key4hep-spack/config/cvmfs_build/config-nightlies.yaml spack/etc/spack/config.yaml
         - export K4_LATEST_SETUP_PATH=/cvmfs/sw-nightlies.hsf.org/spackages/latest/setup.sh
         # compile onwards and upwards
-        - spack install key4hep-stack@master-`date -I` 
+        - spack install --no-checksum key4hep-stack@master-`date -I` 
 
 
 ### deploy the nightlies to cvmfs


### PR DESCRIPTION
…mit versions