### PR TITLE
Require cxxstd=17 for geant4

### DIFF
--- a/config/packages.yaml
+++ b/config/packages.yaml
@@ -2,7 +2,7 @@
 packages:
   all:
     target: [broadwell]
-    variants: build_type=Release
+    variants: build_type=Release cxxstd=17
     buildable: true
     version: []
     providers:

--- a/config/packages.yaml
+++ b/config/packages.yaml
@@ -24,7 +24,7 @@ packages:
     providers: {}
     compiler: []
   geant4:
-    variants: ~qt~opengl+vecgeom
+    variants: ~qt~opengl+vecgeom cxxstd=17
     buildable: true
     version: []
     target: []


### PR DESCRIPTION
Make it more consistent with the usage of this variant throughout the stack.
Also see #149 for a bit of context on why this might be useful.