### PR TITLE
Use delphes 3.4.3pre08

### DIFF
--- a/config/packages.yaml
+++ b/config/packages.yaml
@@ -90,7 +90,7 @@ packages:
     providers: {}
     compiler: []
   delphes:
-    version: [3.4.3pre06]
+    version: [3.4.3pre08]
     buildable: true
     target: []
     providers: {}


### PR DESCRIPTION
Once it is available: spack/spack#21221

Contains some fixes to TrackCovariance that would be nice to pick up in the next release if possible.