### PR TITLE
Add environment for workflow to install geant-data packages to share dir

### DIFF
--- a/environments/geant4-data-share/compilers_centos7_cvmfs.yaml
+++ b/environments/geant4-data-share/compilers_centos7_cvmfs.yaml
@@ -1,0 +1,1 @@
+../../config/compilers_centos7_cvmfs.yaml

--- a/environments/geant4-data-share/spack.yaml
+++ b/environments/geant4-data-share/spack.yaml
@@ -1,0 +1,19 @@
+spack:
+  include:
+    - compilers_centos7_cvmfs.yaml
+  config:
+    install_tree:
+      root: /cvmfs/sw.hsf.org/share
+      projections:
+        all: data/${PACKAGE}-${VERSION}-${HASH}
+    module_roots:
+      lmod: /cvmfs/sw.hsf.org/spackages/modules
+      tcl: /cvmfs/sw.hsf.org/spackages/modules
+  view: false
+  packages:
+    all:
+      target: [broadwell]
+      variants: build_type=Release
+  specs:
+  - geant4-data@10.7.0
+  - geant4-data@10.7.1


### PR DESCRIPTION
The workaround for not duplicating all the data packages across different compiler/release-debug/... installations requires having a dedicated workflow to update them when there is a new release of geant-data. Previously I did this manually, this adds now an environment to do the same thing.