### PR TITLE
Add man-db to stack

### DIFF
--- a/packages/key4hep-stack/package.py
+++ b/packages/key4hep-stack/package.py
@@ -140,6 +140,7 @@ class Key4hepStack(BundlePackage, Key4hepPackage):
     ##################### developer tools #################
     #######################################################
     depends_on("cmake", when="+devtools")
+    depends_on('man-db', when="+devtools")
     depends_on("gdb", "when=+devtools")
     depends_on("emacs+X toolkit=athena", when="+devtools")
     depends_on("ninja", when="+devtools")


### PR DESCRIPTION
Per request, avoids an error because many system-provided `man`s cannot handle the long manpath list that spack produces.

