### PR TITLE
evtgen: build with photos

### DIFF
--- a/environments/key4hep-common/packages.yaml
+++ b/environments/key4hep-common/packages.yaml
@@ -154,3 +154,5 @@ packages:
     target: [haswell]
   groff:
     variants: ~pdf
+  evtgen:
+    variants: +photos


### PR DESCRIPTION
Build evtgen with photos enabled in the standard key4hep build environments - as requested by @clementhelsens. This silences a warning `EvtGen:EvtAbsExternalGen::getGenerator: could not find generator for genId = 1`.
