### PR TITLE
Fix spurious notifications about new versions

### DIFF
--- a/.github/scripts/generate_new_version_issue.sh
+++ b/.github/scripts/generate_new_version_issue.sh
@@ -8,6 +8,10 @@ package_list=$(spack maintainers --by-user vvolkl mirguest tmadlener)
 #package_list=$(echo ${package_list} | tr ' ' '\n' | sort | uniq | tr '\n' ' ' | sed -e 's/[[:space:]]*$//')
 
 for p in ${package_list}; do
+  # ignore deprecated packages
+  if [[ "$p" == "py-awkward1" ]] || [[ "$p" == "py-uproot4" ]]; then
+    continue
+  fi
   v=$(spack versions --new $p)
   # ignore pre and rc versions
   v=$(echo $v | sed 's/\S*\(rc\|pre\|alpha\)\S*//g')

--- a/packages/fccdetectors/package.py
+++ b/packages/fccdetectors/package.py
@@ -4,9 +4,9 @@ from spack.pkg.k4.Ilcsoftpackage import Key4hepPackage, k4_add_latest_commit_as_
 
 class Fccdetectors(CMakePackage, Key4hepPackage):
     """Software framework of the FCC project"""
-    homepage = "https://github.com/HEP-FCC/fccDetectors/"
-    url      = "https://github.com/HEP-FCC/fccDetectors/archive/v0.16.tar.gz"
-    git      = "https://github.com/HEP-FCC/fccDetectors.git"
+    homepage = "https://github.com/HEP-FCC/FCCDetectors/"
+    url      = "https://github.com/HEP-FCC/FCCDetectors/archive/refs/tags/v0.1pre03.tar.gz"
+    git      = "https://github.com/HEP-FCC/FCCDetectors.git"
 
     maintainers = ['vvolkl']
 

--- a/packages/k4gen/package.py
+++ b/packages/k4gen/package.py
@@ -5,12 +5,13 @@ from spack.pkg.k4.Ilcsoftpackage import Key4hepPackage, k4_add_latest_commit_as_
 class K4gen(CMakePackage, Key4hepPackage):
     """Generator components for the Key4hep framework"""
     homepage = "https://github.com/HEP-FCC/k4Gen/"
-    url      = "https://github.com/HEP-FCC/k4Gen/archive/v0.16.tar.gz"
+    url      = "https://github.com/HEP-FCC/k4Gen/archive/refs/tags/v0.1pre02.tar.gz"
     git      = "https://github.com/HEP-FCC/k4Gen.git"
 
     maintainers = ['vvolkl']
 
     version('master', branch='master')
+    version('0.1pre02', tag='0.1pre02')
     version('0.1pre01', tag='0.1pre01')
 
     generator = 'Ninja'

--- a/packages/k4reccalorimeter/package.py
+++ b/packages/k4reccalorimeter/package.py
@@ -5,7 +5,7 @@ from spack.pkg.k4.Ilcsoftpackage import Key4hepPackage, k4_add_latest_commit_as_
 class K4reccalorimeter(CMakePackage, Key4hepPackage):
     """Generator components for the Key4hep framework"""
     homepage = "https://github.com/HEP-FCC/k4RecCalorimeter/"
-    url      = "https://github.com/HEP-FCC/k4RecCalorimeter/archive/v0.16.tar.gz"
+    url      = "https://github.com/HEP-FCC/k4RecCalorimeter/archive/refs/tags/v0.1.0pre04.tar.gz"
     git      = "https://github.com/HEP-FCC/k4RecCalorimeter.git"
 
     maintainers = ['vvolkl']


### PR DESCRIPTION
Ignore deprecated packages from the check, and fix the url of some others so `spack versions -n ` gives sensible result.
