### PR TITLE
Add compilers.yaml and use environment in workflows

### DIFF
--- a/.github/workflows/concretize-lxplus-pr-target.yaml
+++ b/.github/workflows/concretize-lxplus-pr-target.yaml
@@ -40,7 +40,9 @@ jobs:
       run: |
         docker exec CI_container /bin/bash -c 'cd ./Package;\
         source spack/share/spack/setup-env.sh;\
-        spack spec -I key4hep-stack | tee -a key4hep-stack-concretization.log;'
+        spack env activate environments/key4hep-release-user/
+        spack add key4hep-stack
+        spack concretize -f | tee -a key4hep-stack-concretization.log;'
     - name: Comment PR 
       env:
         KEY4HEP_COMMENT_BOT_TOKEN: ${{ secrets.KEY4HEP_COMMENT_BOT_TOKEN }}

--- a/.github/workflows/concretize-lxplus.yaml
+++ b/.github/workflows/concretize-lxplus.yaml
@@ -24,7 +24,9 @@ jobs:
       run: |
         docker exec CI_container /bin/bash -c 'cd ./Package;\
         source spack/share/spack/setup-env.sh;\
-        spack spec -I key4hep-stack | tee -a key4hep-stack-concretization.log;'
+        spack env activate environments/key4hep-release-user/
+        spack add key4hep-stack
+        spack concretize -f | tee -a key4hep-stack-concretization.log;'
     - uses: actions/upload-artifact@v2
       with:
         name: concretization-log-artifact

--- a/environments/key4hep-common/compilers.yaml
+++ b/environments/key4hep-common/compilers.yaml
@@ -1,0 +1,28 @@
+compilers:
+  - compiler:
+      paths:
+        cc: /cvmfs/sw.hsf.org/spackages2/gcc/8.3.0/x86_64-centos7-gcc8.3.0-opt/u7dp2lgebeosqhdmqrx3boeussoyrf5k/bin/gcc
+        cxx: /cvmfs/sw.hsf.org/spackages2/gcc/8.3.0/x86_64-centos7-gcc8.3.0-opt/u7dp2lgebeosqhdmqrx3boeussoyrf5k/bin/g++
+        f77: /cvmfs/sw.hsf.org/spackages2/gcc/8.3.0/x86_64-centos7-gcc8.3.0-opt/u7dp2lgebeosqhdmqrx3boeussoyrf5k/bin/gfortran
+        fc: /cvmfs/sw.hsf.org/spackages2/gcc/8.3.0/x86_64-centos7-gcc8.3.0-opt/u7dp2lgebeosqhdmqrx3boeussoyrf5k/bin/gfortran
+      operating_system: centos7
+      target: x86_64
+      modules: []
+      environment: {}
+      extra_rpaths: []
+      flags: {}
+      spec: gcc@8.3.0
+  - compiler:
+        paths:
+          cc: /cvmfs/sw.hsf.org/spackages2/llvm/12.0.0/x86_64-centos7-gcc8.3.0-opt/qn66fgxvj635hojell4cebin7zkbv6g4/bin/clang
+          cxx: /cvmfs/sw.hsf.org/spackages2/llvm/12.0.0/x86_64-centos7-gcc8.3.0-opt/qn66fgxvj635hojell4cebin7zkbv6g4/bin/clang++
+          f77: /cvmfs/sw.hsf.org/spackages2/gcc/8.3.0/x86_64-centos7-gcc8.3.0-opt/u7dp2lgebeosqhdmqrx3boeussoyrf5k/bin/gfortran
+          fc: /cvmfs/sw.hsf.org/spackages2/gcc/8.3.0/x86_64-centos7-gcc8.3.0-opt/u7dp2lgebeosqhdmqrx3boeussoyrf5k/bin/gfortran
+        operating_system: centos7
+        target: x86_64
+        modules: []
+        environment: {}
+        extra_rpaths: []
+        flags: {}
+        spec: clang@12.0.0
+

--- a/environments/key4hep-debug/compilers.yaml
+++ b/environments/key4hep-debug/compilers.yaml
@@ -1,0 +1,1 @@
+../key4hep-common/compilers.yaml

--- a/environments/key4hep-debug/spack.yaml
+++ b/environments/key4hep-debug/spack.yaml
@@ -3,6 +3,7 @@ spack:
   - key4hep-config.yaml
   - geant4-data.yaml
   - key4hep-packages.yaml
+  - compilers.yaml
   upstreams:
     spack-instance-21:
       install_tree: /cvmfs/sw.hsf.org/spackages/

--- a/environments/key4hep-nightlies-debug/compilers.yaml
+++ b/environments/key4hep-nightlies-debug/compilers.yaml
@@ -1,0 +1,1 @@
+../key4hep-common/compilers.yaml

--- a/environments/key4hep-nightlies-debug/spack.yaml
+++ b/environments/key4hep-nightlies-debug/spack.yaml
@@ -17,6 +17,7 @@ spack:
   include:
   - geant4-data.yaml
   - key4hep-packages.yaml
+  - compilers.yaml
   packages:
     all:
       variants: build_type=Debug cxxstd=17

--- a/environments/key4hep-nightlies/compilers.yaml
+++ b/environments/key4hep-nightlies/compilers.yaml
@@ -1,0 +1,1 @@
+../key4hep-common/compilers.yaml

--- a/environments/key4hep-nightlies/spack.yaml
+++ b/environments/key4hep-nightlies/spack.yaml
@@ -19,6 +19,7 @@ spack:
   include:
   - geant4-data.yaml
   - key4hep-packages.yaml
+  - compilers.yaml
   packages:
     qhull:
       variants: build_type=Release

--- a/environments/key4hep-release-broadwell/compilers.yaml
+++ b/environments/key4hep-release-broadwell/compilers.yaml
@@ -1,0 +1,1 @@
+../key4hep-common/compilers.yaml

--- a/environments/key4hep-release-broadwell/spack.yaml
+++ b/environments/key4hep-release-broadwell/spack.yaml
@@ -3,6 +3,7 @@ spack:
   - key4hep-config.yaml
   - geant4-data.yaml
   - key4hep-packages.yaml
+  - compilers.yaml
   packages:
     all:
       target: [broadwell]

--- a/environments/key4hep-release-user/compilers.yaml
+++ b/environments/key4hep-release-user/compilers.yaml
@@ -1,0 +1,1 @@
+../key4hep-common/compilers.yaml

--- a/environments/key4hep-release-user/spack.yaml
+++ b/environments/key4hep-release-user/spack.yaml
@@ -3,6 +3,7 @@ spack:
   - /cvmfs/sw.hsf.org/contrib/spack/var/spack/repos/key4hep-spack/environments/key4hep-common/config.yaml
   - /cvmfs/sw.hsf.org/contrib/spack/var/spack/repos/key4hep-spack/environments/geant4-data-share/geant4-data.yaml
   - /cvmfs/sw.hsf.org/contrib/spack/var/spack/repos/key4hep-spack/environments/key4hep-common/packages.yaml
+  - /cvmfs/sw.hsf.org/contrib/spack/var/spack/repos/key4hep-spack/environments/key4hep-common/compilers.yaml
   view: false
   modules:
     enable: []

--- a/environments/key4hep-release/compilers.yaml
+++ b/environments/key4hep-release/compilers.yaml
@@ -1,0 +1,1 @@
+../key4hep-common/compilers.yaml

--- a/environments/key4hep-release/spack.yaml
+++ b/environments/key4hep-release/spack.yaml
@@ -3,6 +3,7 @@ spack:
   - key4hep-config.yaml
   - geant4-data.yaml
   - key4hep-packages.yaml
+  - compilers.yaml
   view: false
   modules:
     enable: []

--- a/scripts/ci_setup_spack.sh
+++ b/scripts/ci_setup_spack.sh
@@ -3,6 +3,7 @@
  source spack/share/spack/setup-env.sh
 # get the right config files to the right places
  cp environments/key4hep-common/packages.yaml spack/etc/spack/
+ cp environments/key4hep-common/compilers.yaml spack/etc/spack/
  mkdir spack/var/spack/repos/key4hep-spack
  cp -r * spack/var/spack/repos/key4hep-spack || true
 # clean up git directories for zip
@@ -13,7 +14,4 @@
  echo ' - $SPACK_ROOT/var/spack/repos/key4hep-spack' >> spack/etc/spack/repos.yaml
  tar -czf key4hep-spack.tar.gz spack
  cp ${PWD}/spack/var/spack/repos/key4hep-spack/config/cvmfs_build/upstreams.yaml spack/etc/spack/
-# compiler setup 
- spack load gcc
- spack compiler find --scope site
  tar -czf key4hep-spack_centos7-cvmfs.tar.gz spack


### PR DESCRIPTION
* Hardcodes the compiler on cvmfs for environments that are intended to use cvmfs, hopefully making it more robust (avoiding errors due to `spack load gcc` failing)
* start using the `user` environment in ci workflows
