### PR TITLE
[commentbot] comment on existing issue instead of creating new one

### DIFF
--- a/.github/scripts/generate_new_version_issue.sh
+++ b/.github/scripts/generate_new_version_issue.sh
@@ -13,8 +13,16 @@ for p in ${package_list}; do
     continue
   fi
   v=$(spack versions --new $p)
-  # ignore pre and rc versions
+  # ignore pre and rc versions (for all packages)
   v=$(echo $v | sed 's/\S*\(rc\|pre\|alpha\)\S*//g')
+  # ignore alpha and beta versions for py-kubernetes
+  if [[ "$p" == "py-kubernetes" ]] ; then
+    v=$(echo $v | sed 's/\S*\(a\|b\)\S*//g')
+  fi
+  # ignore version 00-03-02 for edm4hep which has no code changes
+  if [[ "$p" == "edm4hep" ]] ; then
+    v=$(echo $v | sed 's/\S*\(00-03-02\)\S*//g')
+  fi
   if [[ ! -z "$v" ]]; then
     echo "- [ ] \`$p\`: \`$v\` " >> gh-new-version.log
   fi

--- a/.github/scripts/post_new_version_issue_comment.sh
+++ b/.github/scripts/post_new_version_issue_comment.sh
@@ -1,0 +1,18 @@
+generate_new_version_data()
+{
+  cat <<EOF
+{
+  "body": "$(cat gh-new-version.log | sed -z 's/\n/\\n/g')\n"
+}
+EOF
+}
+cat gh-new-version.log
+echo $(generate_new_version_data)
+if [[ -f gh-new-version.log ]]; then
+  curl -s -H "Authorization: token ${KEY4HEP_COMMENT_BOT_TOKEN}" \
+   -X POST -d "$(generate_new_version_data)"  \
+   "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/238/comments"
+else
+  echo "No new versions found"
+fi
+

--- a/.github/workflows/check-new-versions.yaml
+++ b/.github/workflows/check-new-versions.yaml
@@ -40,4 +40,4 @@ jobs:
         cd ${GITHUB_WORKSPACE}/../spack
         source share/spack/setup-env.sh
         ${GITHUB_WORKSPACE}/.github/scripts/generate_new_version_issue.sh
-        ${GITHUB_WORKSPACE}/.github/scripts/post_new_version_issue.sh
+        ${GITHUB_WORKSPACE}/.github/scripts/post_new_version_issue_comment.sh


### PR DESCRIPTION
This creates less clutter on github in my opinion (even though the issues could be filtered by label)


BEGINRELEASENOTES
- [commentbot] comment on existing issue instead of creating new one and update filters

ENDRELEASENOTES
