### PR TITLE
[gitlab] replace pathsetup.sh by env var pointing to installed package

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,4 @@
 
-
 # for compatibility with old git versions on centos
 variables:
   GIT_STRATEGY: clone
@@ -31,10 +30,10 @@ setup_spack_push:
 
     artifacts:
         paths:
-            - key4hep-spack_centos7-cvmfs.tar.gz
             - key4hep-spack.tar.gz
+            - key4hep-spack_centos7-cvmfs.tar.gz
             - spack 
-        expire_in: 1 week
+        expire_in: 1 month
 
 #### Nightly build of key4hep-stack
 # this job expects the following setup on the runner:
@@ -70,7 +69,8 @@ build-spack-nightlies:
         - source spack/share/spack/setup-env.sh
         - export KEY4HEP_RELEASE_VERSION=master-`date -I`
         - cd environments/$SPACKENV
-        - source pathsetup.sh
+        # symlink to latest now handled by deploy step
+        #- source pathsetup.sh
         # avoid bootstrapping clingo
         - source setup_clingo_centos7.sh
         - spack env activate .
@@ -123,20 +123,47 @@ build-spack-release:
     script:
         # set up spack inside the k4-spack repo
         - source spack/share/spack/setup-env.sh
-        # get the right config files to the right places
-        - cp ${PWD}/spack/var/spack/repos/key4hep-spack/config/cvmfs_build/config.yaml spack/etc/spack/config.yaml
-        - rm spack/etc/spack/upstreams.yaml
         # if this workflow has been started by a tag, use the tag version. if not, use todays date
         - if [ -z "$CI_COMMIT_TAG" ]; then export K4STACK_VERSION=`date -I`; else export K4STACK_VERSION=$CI_COMMIT_TAG;  fi 
         - if [ ! -z "$CI_BUILD_TAG" ]; then export K4STACK_VERSION=$CI_BUILD_TAG;  fi 
-        # compile onwards and upwards
         - echo $K4STACK_VERSION
+        # activate environment
         - cd environments/${SPACKENV}
-        - source ./pathsetup.sh
-        - echo $K4_LATEST_SETUP_PATH
         - spack env activate .
+        # config debug printouts
+        - spack config blame config # debug printout
+        - spack config blame packages # debug printout
+        # in order to set the right version for the key4hep-stack spec, we add it to the
+        # environment now when we now it
         - spack add key4hep-stack@${K4STACK_VERSION}
-        - spack install --fail-fast key4hep-stack | tee -a key4hep-stack-install.log
+        # compile onwards and upwards
+        - spack install --fail-fast | tee -a key4hep-stack-install.log
+        # note the path of the just installed package
+        # so that downstream jobs can source its setup
+        # in an environment, this command should just find the specs  
+        # installed in this environment
+        - spack find -p key4hep-stack@${K4STACK_VERSION} > spackfind.log
+        - cat spackfind.log # debug printout
+        # parse output of spack find
+        # the last line should be, p.ex.
+        # zlib@1.2.11  /cvmfs/sw.hsf.org/spackages/linux-ubuntu20.04-broadwell/gcc-9.3.0/zlib-1.2.11-emkoq3o2mtu377gy6plexktmkqchkgkb
+        # cut can only be used to get the first field - do a double reverse of the string to get the last
+        - SPACKENV_PATH=$(tail -n 1 spackfind.log  |  rev | cut -d " " -f1 | rev)
+        - echo ${SPACKENV_PATH} # debug printout
+        # we want to use the environment name as a variable name
+        # so need to remove some special characters (right now only the hyphen)
+        - echo ${SPACKENV/-/} # debug printout
+        # make the path available to downstream jobs 
+        # for example:
+        #key4hepdebug_PATH=/cvmfs/sw.hsf.org/spackages2/key4hep-stack/2021-06-16/x86_64-centos7-gcc8.3.0-dbg/a7xzrrsha54w4mewe43b4bmxaqxnvg2x
+        - echo "${SPACKENV/-/}_PATH=${SPACKENV_PATH}" >> build.env
+        - cat build.env # debug printout
+    artifacts:
+        # the log could be saved as an artifact, but does not really have more info than stdout
+        #paths:
+        #  - environments/${SPACKENV}/key4hep-stack-install.log
+        reports:
+          dotenv: environments/${SPACKENV}/build.env
 
 
 buildtest-spack-release:
@@ -158,11 +185,13 @@ buildtest-spack-release:
       variables:
           - $K4_JOBTYPE == "Release"
     script:
-        - echo ${SPACKENV}
-        - ls environments/${SPACKENV}
-        - source environments/${SPACKENV}/pathsetup.sh
-        - echo ${K4_LATEST_SETUP_PATH}
-        - source ${K4_LATEST_SETUP_PATH}
+        - echo ${SPACKENV} # debug printout
+        - ls environments/${SPACKENV} # debug printout
+        # resolve dynamic variable name
+        - K4_SETUP_PATH=${SPACKENV/-/}_PATH
+        - echo ${!K4_SETUP_PATH} # debug printout
+        # run tests, to fail early, even before publishing
+        - source ${!K4_SETUP_PATH}/setup.sh
         - ./scripts/ci_install_tests.sh
 
 
@@ -179,6 +208,7 @@ deploy-cvmfs-release:
       variables:
           - $K4_JOBTYPE == "Release"
     script:
+        # todo: once the publisher is set up as a gitlab runner, use the script from the repo
         - ssh cvswhsforg@cvmfs-sw-hsf-org.cern.ch ' bash -c ./cvmfs_deploy.sh'
 
 wait-cvmfs-release:
@@ -202,9 +232,13 @@ wait-cvmfs-release:
       variables:
           - $K4_JOBTYPE == "Release"
     script:
-        - source environments/${SPACKENV}/pathsetup.sh
-        - echo ${K4_LATEST_SETUP_PATH}
-        - while [ ! -f ${K4_LATEST_SETUP_PATH} ]; do sleep 10; done
+        # resolve dynamic variable name
+        - K4_LATEST_SETUP_PATH=${SPACKENV/-/}_PATH
+        - echo ${!K4_LATEST_SETUP_PATH} # debug printout
+        # wait for the new release to be present on cvmfs
+        # both to be sure that it is available once the pipeline finishes
+        # and so the final install test can use it to check the publication
+        - while [ ! -f ${!K4_LATEST_SETUP_PATH}/setup.sh ]; do sleep 10; done
 
 test-cvmfs-release:
     stage: installtest
@@ -223,9 +257,10 @@ test-cvmfs-release:
       variables:
           - $K4_JOBTYPE == "Release"
     script:
-        - source environments/${SPACKENV}/pathsetup.sh
-        - echo ${K4_LATEST_SETUP_PATH}
-        - source ${K4_LATEST_SETUP_PATH}
+        # resolve dynamic variable name
+        - K4_LATEST_SETUP_PATH=${SPACKENV/-/}_PATH
+        - echo ${!K4_LATEST_SETUP_PATH} # debug printout
+        - source ${!K4_LATEST_SETUP_PATH}/setup.sh
         - ./scripts/ci_install_tests.sh
 
 

--- a/environments/key4hep-debug/pathsetup.sh
+++ b/environments/key4hep-debug/pathsetup.sh
@@ -1,1 +1,0 @@
-export K4_LATEST_SETUP_PATH=/cvmfs/sw.hsf.org/spackages/latest/x86_64-centos7-gcc8-dbg/setup.sh

--- a/environments/key4hep-nightlies-debug/pathsetup.sh
+++ b/environments/key4hep-nightlies-debug/pathsetup.sh
@@ -1,1 +1,0 @@
-export K4_LATEST_SETUP_PATH=/cvmfs/sw-nightlies.hsf.org/spackages/latest/x86_64-centos7-gcc8-dbg/setup.sh

--- a/environments/key4hep-nightlies/pathsetup.sh
+++ b/environments/key4hep-nightlies/pathsetup.sh
@@ -1,1 +1,0 @@
-export K4_LATEST_SETUP_PATH=/cvmfs/sw-nightlies.hsf.org/spackages/latest/x86_64-centos7-gcc8-opt/setup.sh

--- a/environments/key4hep-release-broadwell/pathsetup.sh
+++ b/environments/key4hep-release-broadwell/pathsetup.sh
@@ -1,1 +1,0 @@
-export K4_LATEST_SETUP_PATH=/cvmfs/sw.hsf.org/spackages/latest/x86_64-centos7-gcc8-opt/setup.sh

--- a/environments/key4hep-release/pathsetup.sh
+++ b/environments/key4hep-release/pathsetup.sh
@@ -1,1 +1,0 @@
-export K4_LATEST_SETUP_PATH=/cvmfs/sw.hsf.org/spackages/latest/x86_64-centos7-gcc8-opt/setup.sh

--- a/scripts/ci_setup_spack.sh
+++ b/scripts/ci_setup_spack.sh
@@ -1,9 +1,6 @@
 # set up spack inside the k4-spack repo
  if [ -n "$SPACK_VERSION" ]; then git clone  https://github.com/key4hep/spack ; cd spack; git checkout $SPACK_VERSION; cd ..; else git clone --depth 1 https://github.com/key4hep/spack; fi 
  source spack/share/spack/setup-env.sh
-# get the right config files to the right places
- cp environments/key4hep-common/packages.yaml spack/etc/spack/
- cp environments/key4hep-common/compilers.yaml spack/etc/spack/
  mkdir spack/var/spack/repos/key4hep-spack
  cp -r * spack/var/spack/repos/key4hep-spack || true
 # clean up git directories for zip
@@ -12,6 +9,13 @@
 # register k4 package recipes with spack
  echo "repos:" > spack/etc/spack/repos.yaml
  echo ' - $SPACK_ROOT/var/spack/repos/key4hep-spack' >> spack/etc/spack/repos.yaml
- tar -czf key4hep-spack.tar.gz spack
+# get the right config files to the right places
  cp ${PWD}/spack/var/spack/repos/key4hep-spack/config/cvmfs_build/upstreams.yaml spack/etc/spack/
+ cp ${PWD}/spack/var/spack/repos/key4hep-spack/environments/key4hep-common/packages.yaml spack/etc/spack/
+ cp ${PWD}/spack/var/spack/repos/key4hep-spack/environments/key4hep-common/compilers.yaml spack/etc/spack/
  tar -czf key4hep-spack_centos7-cvmfs.tar.gz spack
+# remove the config files again 
+ rm spack/etc/spack/upstreams.yaml
+ rm spack/etc/spack/compilers.yaml
+ rm spack/etc/spack/packages.yaml
+ tar -czf key4hep-spack.tar.gz spack


### PR DESCRIPTION
Since the new package path projections are used, the way the path to the setup scripts are made availabe needs to be updated.

BEGINRELEASENOTES
- [gitlab] replace pathsetup.sh by env var pointing to installed package

ENDRELEASENOTES
