### PR TITLE
[marlinutil] Make sure correct GSL is picked by cmake

### DIFF
--- a/packages/marlinutil/package.py
+++ b/packages/marlinutil/package.py
@@ -31,3 +31,7 @@ class Marlinutil(CMakePackage, Ilcsoftpackage):
     depends_on('ced')
     depends_on('dd4hep')
     depends_on('root')
+
+    def cmake_args(self):
+        # Make sure that we pick the right GSL
+        return ['-DGSL_DIR={}'.format(self.spec['gsl'].prefix)]


### PR DESCRIPTION
BEGINRELEASENOTES
- Make sure that the right GSL is picked during the build. Otherwise an unsuitable version from the underlying system might be chosen.

ENDRELEASENOTES
