### PR TITLE
[k4marlinwrapper] Add catch2 dependency for latest versions

### DIFF
--- a/packages/k4marlinwrapper/package.py
+++ b/packages/k4marlinwrapper/package.py
@@ -33,6 +33,7 @@ class K4marlinwrapper(CMakePackage, Ilcsoftpackage):
     depends_on('edm4hep')
     depends_on('k4lcioreader')
     depends_on('wget', type=('test'))
+    depends_on('catch2@3.0.1:', when='@0.3.2:', type=('build', 'test'))
 
     def cmake_args(self):
         args = []

--- a/packages/k4marlinwrapper/package.py
+++ b/packages/k4marlinwrapper/package.py
@@ -33,7 +33,7 @@ class K4marlinwrapper(CMakePackage, Ilcsoftpackage):
     depends_on('edm4hep')
     depends_on('k4lcioreader')
     depends_on('wget', type=('test'))
-    depends_on('catch2@3.0.1:', when='@0.3.2:', type=('build', 'test'))
+    depends_on('catch2@3.0.1:', when='@0.3.2:', type=('test'))
 
     def cmake_args(self):
         args = []


### PR DESCRIPTION
BEGINRELEASENOTES
- Add catch2 dependency to k4MarlinWrapper recipe for latest versions

ENDRELEASENOTES
