### PR TITLE
Move refactored recipe code to key4hep-stack/common.py

### DIFF
--- a/packages/aidatt/package.py
+++ b/packages/aidatt/package.py
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage 
-from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage 
+from spack.pkg.k4.key4hep_stack import ilc_url_for_version, k4_add_latest_commit_as_version
 
 
 class Aidatt(CMakePackage, Ilcsoftpackage):

--- a/packages/ced/package.py
+++ b/packages/ced/package.py
@@ -5,7 +5,7 @@
 
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
 class Ced(CMakePackage, Ilcsoftpackage):

--- a/packages/cedviewer/package.py
+++ b/packages/cedviewer/package.py
@@ -5,7 +5,7 @@
 
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 class Cedviewer(CMakePackage, Ilcsoftpackage):
     """CEDViewer processor for the CED event display."""

--- a/packages/cepcsw/package.py
+++ b/packages/cepcsw/package.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------------
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Key4hepPackage, k4_add_latest_commit_as_version 
+from spack.pkg.k4.key4hep_stack import Key4hepPackage, k4_add_latest_commit_as_version 
 
 
 class Cepcsw(CMakePackage, Key4hepPackage):

--- a/packages/clicperformance/package.py
+++ b/packages/clicperformance/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 
 class Clicperformance(CMakePackage, Ilcsoftpackage):

--- a/packages/clupatra/package.py
+++ b/packages/clupatra/package.py
@@ -5,7 +5,7 @@
 
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
 class Clupatra(CMakePackage, Ilcsoftpackage):

--- a/packages/conddbmysql/package.py
+++ b/packages/conddbmysql/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Key4hepPackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Key4hepPackage, k4_add_latest_commit_as_version
 
 
 class Conddbmysql(CMakePackage, Key4hepPackage):

--- a/packages/conformaltracking/package.py
+++ b/packages/conformaltracking/package.py
@@ -5,7 +5,7 @@
 
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
 class Conformaltracking(CMakePackage, Ilcsoftpackage):

--- a/packages/ddkaltest/package.py
+++ b/packages/ddkaltest/package.py
@@ -5,7 +5,7 @@
 
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
 class Ddkaltest(CMakePackage, Ilcsoftpackage):

--- a/packages/ddmarlinpandora/package.py
+++ b/packages/ddmarlinpandora/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
 class Ddmarlinpandora(CMakePackage, Ilcsoftpackage):

--- a/packages/dual-readout/package.py
+++ b/packages/dual-readout/package.py
@@ -5,7 +5,7 @@
 
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Key4hepPackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Key4hepPackage, k4_add_latest_commit_as_version
 
 
 class DualReadout(CMakePackage, Key4hepPackage):

--- a/packages/fcalclusterer/package.py
+++ b/packages/fcalclusterer/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
 class Fcalclusterer(CMakePackage, Ilcsoftpackage):

--- a/packages/fcc-edm/package.py
+++ b/packages/fcc-edm/package.py
@@ -1,6 +1,6 @@
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Key4hepPackage, k4_add_latest_commit_as_version 
+from spack.pkg.k4.key4hep_stack import Key4hepPackage, k4_add_latest_commit_as_version 
 
 class FccEdm(CMakePackage, Key4hepPackage):
     """Event data model of FCC"""

--- a/packages/fccanalyses/package.py
+++ b/packages/fccanalyses/package.py
@@ -1,4 +1,4 @@
-from spack.pkg.k4.Ilcsoftpackage import Key4hepPackage
+from spack.pkg.k4.key4hep_stack import Key4hepPackage
 
 class Fccanalyses(CMakePackage, Key4hepPackage):
     """ RDF Analysers for the FCC. """

--- a/packages/fccdetectors/package.py
+++ b/packages/fccdetectors/package.py
@@ -1,6 +1,6 @@
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Key4hepPackage, k4_add_latest_commit_as_version 
+from spack.pkg.k4.key4hep_stack import Key4hepPackage, k4_add_latest_commit_as_version 
 
 class Fccdetectors(CMakePackage, Key4hepPackage):
     """Software framework of the FCC project"""

--- a/packages/fccsw/package.py
+++ b/packages/fccsw/package.py
@@ -1,6 +1,6 @@
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Key4hepPackage, k4_add_latest_commit_as_version 
+from spack.pkg.k4.key4hep_stack import Key4hepPackage, k4_add_latest_commit_as_version 
 
 class Fccsw(CMakePackage, Key4hepPackage):
     """Software framework of the FCC project"""
@@ -9,6 +9,7 @@ class Fccsw(CMakePackage, Key4hepPackage):
     git      = "https://github.com/HEP-FCC/FCCSW.git"
 
     maintainers = ['vvolkl']
+
 
     version('master', branch='master')
     version('1.0pre05', tag="v1.0pre05")

--- a/packages/forwardtracking/package.py
+++ b/packages/forwardtracking/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
 class Forwardtracking(CMakePackage, Ilcsoftpackage):

--- a/packages/garlic/package.py
+++ b/packages/garlic/package.py
@@ -5,7 +5,7 @@
 
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
 class Garlic(CMakePackage, Ilcsoftpackage):

--- a/packages/gear/package.py
+++ b/packages/gear/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
 class Gear(CMakePackage, Ilcsoftpackage):

--- a/packages/ilcsoft/package.py
+++ b/packages/ilcsoft/package.py
@@ -5,9 +5,9 @@ import llnl.util.tty as tty
 import spack.architecture as architecture
 from spack.main import get_version
 import spack.user_environment as uenv
-from spack.pkg.k4.Ilcsoftpackage import k4_add_latest_commit_as_dependency 
-from spack.pkg.k4.Ilcsoftpackage import k4_generate_setup_script 
-from spack.pkg.k4.Ilcsoftpackage import Key4hepPackage
+from spack.pkg.k4.key4hep_stack import k4_add_latest_commit_as_dependency 
+from spack.pkg.k4.key4hep_stack import k4_generate_setup_script 
+from spack.pkg.k4.key4hep_stack import Key4hepPackage
 
 
 class Ilcsoft(BundlePackage, Key4hepPackage):

--- a/packages/ilcutil/package.py
+++ b/packages/ilcutil/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
 class Ilcutil(CMakePackage, Ilcsoftpackage):

--- a/packages/ildperformance/package.py
+++ b/packages/ildperformance/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
 class Ildperformance(CMakePackage, Ilcsoftpackage):

--- a/packages/k4actstracking/package.py
+++ b/packages/k4actstracking/package.py
@@ -1,6 +1,6 @@
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Key4hepPackage
+from spack.pkg.k4.key4hep_stack import Key4hepPackage
 
 class K4actstracking(BundlePackage, Key4hepPackage):
     """Acts tracking components for the key4hep project"""

--- a/packages/k4fwcore/package.py
+++ b/packages/k4fwcore/package.py
@@ -1,5 +1,5 @@
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Key4hepPackage, k4_add_latest_commit_as_version,  ilc_url_for_version
+from spack.pkg.k4.key4hep_stack import Key4hepPackage, k4_add_latest_commit_as_version,  ilc_url_for_version
 
 
 class K4fwcore(CMakePackage, Key4hepPackage):

--- a/packages/k4gen/package.py
+++ b/packages/k4gen/package.py
@@ -1,6 +1,6 @@
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Key4hepPackage, k4_add_latest_commit_as_version 
+from spack.pkg.k4.key4hep_stack import Key4hepPackage, k4_add_latest_commit_as_version 
 
 class K4gen(CMakePackage, Key4hepPackage):
     """Generator components for the Key4hep framework"""

--- a/packages/k4lcioreader/package.py
+++ b/packages/k4lcioreader/package.py
@@ -1,6 +1,6 @@
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Key4hepPackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Key4hepPackage, k4_add_latest_commit_as_version
 
 class K4lcioreader(CMakePackage, Key4hepPackage):
     """LCIO reader based on PODIO and EDM4hep"""

--- a/packages/k4marlinwrapper/package.py
+++ b/packages/k4marlinwrapper/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 class K4marlinwrapper(CMakePackage, Ilcsoftpackage):
     """Gaudify Marlin Processors in order to run them in the Key4HEP framework"""

--- a/packages/k4pandora/package.py
+++ b/packages/k4pandora/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Key4hepPackage, k4_add_latest_commit_as_version 
+from spack.pkg.k4.key4hep_stack import Key4hepPackage, k4_add_latest_commit_as_version 
 
 
 class K4pandora(CMakePackage, Key4hepPackage):

--- a/packages/k4projecttemplate/package.py
+++ b/packages/k4projecttemplate/package.py
@@ -1,6 +1,6 @@
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Key4hepPackage
+from spack.pkg.k4.key4hep_stack import Key4hepPackage
 
 class K4projecttemplate(CMakePackage, Key4hepPackage):
     """Template for Key4hep framework projects"""

--- a/packages/k4reccalorimeter/package.py
+++ b/packages/k4reccalorimeter/package.py
@@ -1,6 +1,6 @@
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Key4hepPackage, k4_add_latest_commit_as_version 
+from spack.pkg.k4.key4hep_stack import Key4hepPackage, k4_add_latest_commit_as_version 
 
 class K4reccalorimeter(CMakePackage, Key4hepPackage):
     """Calorimeter reconstruction components for the Key4hep framework"""

--- a/packages/k4simdelphes/package.py
+++ b/packages/k4simdelphes/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import ilc_url_for_version, k4_add_latest_commit_as_version
 
 
 class K4simdelphes(CMakePackage):

--- a/packages/k4simgeant4/package.py
+++ b/packages/k4simgeant4/package.py
@@ -1,6 +1,6 @@
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Key4hepPackage, k4_add_latest_commit_as_version 
+from spack.pkg.k4.key4hep_stack import Key4hepPackage, k4_add_latest_commit_as_version 
 
 class K4simgeant4(CMakePackage, Key4hepPackage):
     """Software framework of the FCC project"""

--- a/packages/kaldet/package.py
+++ b/packages/kaldet/package.py
@@ -5,7 +5,7 @@
 
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
 class Kaldet(CMakePackage, Ilcsoftpackage):

--- a/packages/kaltest/package.py
+++ b/packages/kaltest/package.py
@@ -5,7 +5,7 @@
 
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
 class Kaltest(CMakePackage, Ilcsoftpackage):

--- a/packages/key4hep-stack/common.py
+++ b/packages/key4hep-stack/common.py
@@ -1,7 +1,6 @@
-# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
-# Spack Project Developers. See the top-level COPYRIGHT file for details.
-#
-# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""
+Common methods for use in Key4hep recipes
+"""
 
 from spack import *
 

--- a/packages/key4hep-stack/package.py
+++ b/packages/key4hep-stack/package.py
@@ -5,10 +5,13 @@ import llnl.util.tty as tty
 import spack.architecture as architecture
 from spack.main import get_version
 import spack.user_environment as uenv
-from spack.pkg.k4.Ilcsoftpackage import k4_add_latest_commit_as_dependency 
-from spack.pkg.k4.Ilcsoftpackage import k4_generate_setup_script 
-from spack.pkg.k4.Ilcsoftpackage import Key4hepPackage
-
+# import common methods for use in recipe from common.py
+# (so other recipe can import from spack.pkg.k4.key4hep_stack)
+# (which is the most convenient way to make that code available
+#  without creation of a new module
+import sys
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+from common import *
 
 class Key4hepStack(BundlePackage, Key4hepPackage):
     """Bundle package to install the Key4hep software stack."""

--- a/packages/kitrack/package.py
+++ b/packages/kitrack/package.py
@@ -5,7 +5,7 @@
 
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
 class Kitrack(CMakePackage, Ilcsoftpackage):

--- a/packages/kitrackmarlin/package.py
+++ b/packages/kitrackmarlin/package.py
@@ -5,7 +5,7 @@
 
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
 class Kitrackmarlin(CMakePackage, Ilcsoftpackage):

--- a/packages/lccd/package.py
+++ b/packages/lccd/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
 class Lccd(CMakePackage, Ilcsoftpackage):

--- a/packages/lcfiplus/package.py
+++ b/packages/lcfiplus/package.py
@@ -5,7 +5,7 @@
 
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
 class Lcfiplus(CMakePackage, Ilcsoftpackage):

--- a/packages/lcfivertex/package.py
+++ b/packages/lcfivertex/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
 class Lcfivertex(CMakePackage, Ilcsoftpackage):

--- a/packages/lcgeo/package.py
+++ b/packages/lcgeo/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
 class Lcgeo(CMakePackage, Ilcsoftpackage):

--- a/packages/lctuple/package.py
+++ b/packages/lctuple/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
 class Lctuple(CMakePackage, Ilcsoftpackage):

--- a/packages/lich/package.py
+++ b/packages/lich/package.py
@@ -5,7 +5,7 @@
 
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import ilc_url_for_version, k4_add_latest_commit_as_version
 
 
 class Lich(CMakePackage):

--- a/packages/marlin/package.py
+++ b/packages/marlin/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
 class Marlin(CMakePackage, Ilcsoftpackage):

--- a/packages/marlindd4hep/package.py
+++ b/packages/marlindd4hep/package.py
@@ -5,7 +5,7 @@
 
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
 class Marlindd4hep(CMakePackage, Ilcsoftpackage):

--- a/packages/marlinfastjet/package.py
+++ b/packages/marlinfastjet/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
 class Marlinfastjet(CMakePackage, Ilcsoftpackage):

--- a/packages/marlinkinfit/package.py
+++ b/packages/marlinkinfit/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
 class Marlinkinfit(CMakePackage, Ilcsoftpackage):

--- a/packages/marlinkinfitprocessors/package.py
+++ b/packages/marlinkinfitprocessors/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
 class Marlinkinfitprocessors(CMakePackage, Ilcsoftpackage):

--- a/packages/marlinpandora/package.py
+++ b/packages/marlinpandora/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
 class Marlinpandora(CMakePackage, Ilcsoftpackage):

--- a/packages/marlinreco/package.py
+++ b/packages/marlinreco/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
 class Marlinreco(CMakePackage, Ilcsoftpackage):

--- a/packages/marlintrk/package.py
+++ b/packages/marlintrk/package.py
@@ -5,7 +5,7 @@
 
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import ilc_url_for_version, k4_add_latest_commit_as_version
 
 
 class Marlintrk(CMakePackage):

--- a/packages/marlintrkprocessors/package.py
+++ b/packages/marlintrkprocessors/package.py
@@ -5,7 +5,7 @@
 
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
 class Marlintrkprocessors(CMakePackage, Ilcsoftpackage):

--- a/packages/marlinutil/package.py
+++ b/packages/marlinutil/package.py
@@ -5,7 +5,7 @@
 
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
 class Marlinutil(CMakePackage, Ilcsoftpackage):

--- a/packages/overlay/package.py
+++ b/packages/overlay/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
 class Overlay(CMakePackage, Ilcsoftpackage):

--- a/packages/pandoraanalysis/package.py
+++ b/packages/pandoraanalysis/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import ilc_url_for_version, k4_add_latest_commit_as_version
 
 
 class Pandoraanalysis(CMakePackage):

--- a/packages/physsim/package.py
+++ b/packages/physsim/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage 
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage 
 class Physsim(CMakePackage, Ilcsoftpackage):
     """Physsim is a matrix element package."""
 

--- a/packages/raida/package.py
+++ b/packages/raida/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
 class Raida(CMakePackage, Ilcsoftpackage):

--- a/packages/tricktrack/package.py
+++ b/packages/tricktrack/package.py
@@ -1,5 +1,5 @@
 from spack import *
-from spack.pkg.k4.Ilcsoftpackage import k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import k4_add_latest_commit_as_version
 
 
 class Tricktrack(CMakePackage):


### PR DESCRIPTION
BEGINRELEASENOTES
- Move refactored recipe code to key4hep-stack/common.py

ENDRELEASENOTES

This is a better location than the previous `Ilcsoftpackage/package.py` and fixes #268. For a better git history, I kept this code in its own file, which then gets imported transitively through key4hep_stack.