### PR TITLE
Deduplicate init script creation code

### DIFF
--- a/packages/aidatt/package.py
+++ b/packages/aidatt/package.py
@@ -4,9 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage 
-from spack.pkg.k4.key4hep_stack import ilc_url_for_version, k4_add_latest_commit_as_version
-
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 class Aidatt(CMakePackage, Ilcsoftpackage):
     """Tracking toolkit developed in the AIDA project."""

--- a/packages/dual-readout/package.py
+++ b/packages/dual-readout/package.py
@@ -18,6 +18,7 @@ class DualReadout(CMakePackage, Key4hepPackage):
     maintainers = ['vvolkl', 'SanghyunKo']
 
     version('master', branch='master') 
+    k4_add_latest_commit_as_version(git)
     version('0.0.3', sha256='d35e7193c11385505494f11328d54a595b3ff953563bae06b8954c1ef24209b3')
     version('0.0.2', sha256='f76c1febf3d8e29d5287ba03eacbc244f8c615502295f7471579245376da91ad')
 

--- a/packages/k4fwcore/package.py
+++ b/packages/k4fwcore/package.py
@@ -1,14 +1,15 @@
 from spack import *
-from spack.pkg.k4.key4hep_stack import Key4hepPackage, k4_add_latest_commit_as_version,  ilc_url_for_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
-class K4fwcore(CMakePackage, Key4hepPackage):
+class K4fwcore(CMakePackage, Ilcsoftpackage):
     """Core framework components of the Key4HEP project"""
     homepage = "https://github.com/key4hep/k4FWCore"
     url = "https://github.com/key4hep/k4FWCore/archive/v00-01.tar.gz"
     git = "https://github.com/key4hep/k4FWCore.git"
 
     version('master', branch='master')
+    k4_add_latest_commit_as_version(git)
     version('1.0pre12', tag="v01-00pre12") 
     version('0.2.0', sha256='7d1a6e7494f08c2b25901cab2138795f21b6c4e84f05c4f8b9a6839787874b72')
     version('0.1.1', sha256='9c4e4b487f7d9c982547c13570345399505e763fb369b76ceadb35c1d52bf6aa')
@@ -41,9 +42,6 @@ class K4fwcore(CMakePackage, Key4hepPackage):
         if self.spec.satisfies('^gaudi@:34.99'):
           args.append('-DHOST_BINARY_TAG=x86_64-linux-gcc9-opt')
         return args
-
-    def url_for_version(self, version):
-        return ilc_url_for_version(self, version)
 
     def setup_dependent_build_environment(self, spack_env, dependent_spec):
         # needed to set up the runtime dependencies for tests

--- a/packages/k4simdelphes/package.py
+++ b/packages/k4simdelphes/package.py
@@ -3,11 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
 
-from spack.pkg.k4.key4hep_stack import ilc_url_for_version, k4_add_latest_commit_as_version
-
-
-class K4simdelphes(CMakePackage):
+class K4simdelphes(CMakePackage, Ilcsoftpackage):
     """EDM4HEP output for Delphes."""
 
     homepage = "https://github.com/key4hep/k4SimDelphes"
@@ -17,7 +15,7 @@ class K4simdelphes(CMakePackage):
     maintainers = ['vvolkl']
 
     version('main', branch='main')
-
+    k4_add_latest_commit_as_version(git)
     version('00-01-06', sha256='44072ee6fab87ea120481fce6838444467c3c8a00da0ddbfc51a663e119f8f27')
     version('00-01-05', sha256='49aa0942fd80bcef67386eb2a86d2b1bb4bdf2eeb6092c040d2d5c90e63feb3e')
     version('00-01-03', sha256='47a13cb58acda5d52d9462ca85ddf33d72a3dad4d5f5394a4b7078fbe69c0ed1')

--- a/packages/lich/package.py
+++ b/packages/lich/package.py
@@ -5,10 +5,10 @@
 
 
 from spack import *
-from spack.pkg.k4.key4hep_stack import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
-class Lich(CMakePackage):
+class Lich(CMakePackage, Ilcsoftpackage):
     """A marlin processor applied on PFOs for charged particle PID."""
 
     url      = "https://github.com/danerdaner/LICH/archive/v00-01.tar.gz"
@@ -30,9 +30,6 @@ class Lich(CMakePackage):
     
     def setup_run_environment(self, spack_env):
         spack_env.prepend_path('MARLIN_DLL', self.prefix.lib + "/libLICH.so")
-
-    def url_for_version(self, version):
-       return ilc_url_for_version(self, version)
 
     def cmake_args(self):
         return [

--- a/packages/marlintrk/package.py
+++ b/packages/marlintrk/package.py
@@ -5,10 +5,10 @@
 
 
 from spack import *
-from spack.pkg.k4.key4hep_stack import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
-class Marlintrk(CMakePackage):
+class Marlintrk(CMakePackage, Ilcsoftpackage):
     """Tracking Package based on LCIO and GEAR,
        primarily aimed at providing track fitting in Marlin."""
 
@@ -48,6 +48,3 @@ class Marlintrk(CMakePackage):
         args = [self.define_from_variant("MARLINTRK_USE_GEAR", "gear"),
                 '-DCMAKE_CXX_STANDARD=%s' % self.spec['root'].variants['cxxstd'].value]
         return args
-
-    def url_for_version(self, version):
-       return ilc_url_for_version(self, version)

--- a/packages/pandoraanalysis/package.py
+++ b/packages/pandoraanalysis/package.py
@@ -4,10 +4,10 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.k4.key4hep_stack import ilc_url_for_version, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
 
 
-class Pandoraanalysis(CMakePackage):
+class Pandoraanalysis(CMakePackage, Ilcsoftpackage):
     """Pandora calibration and analysis tools in iLCSoft / Marlin framework"""
 
     url      = "https://github.com/PandoraPFA/LCPandoraAnalysis/archive/v02-00-01.tar.gz"
@@ -32,9 +32,6 @@ class Pandoraanalysis(CMakePackage):
 
     def setup_run_environment(self, spack_env):
         spack_env.prepend_path('MARLIN_DLL', self.prefix.lib + "/libPandoraAnalysis.so")
-
-    def url_for_version(self, version):
-       return ilc_url_for_version(self, version)
 
     def cmake_args(self):
         return [


### PR DESCRIPTION
BEGINRELEASENOTES
- Move init/setup script creation functionality into a helper function and call that instead of having two (almost identical) implementations in `ilcsoft` and `key4hep-stack`
- Make use of the `Ilcsoftpackage` where possible and remove dedicated calls to `ilc_url_from_version`

ENDRELEASENOTES

