### PR TITLE
 Add v02-02-03-patch versions of ilcsoft packages

### DIFF
--- a/packages/cedviewer/package.py
+++ b/packages/cedviewer/package.py
@@ -17,6 +17,7 @@ class Cedviewer(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
+    version('1.19', sha256='3446ce55b93de37a84b022c0a3a33097f2089c75dd91b4b5c84c6183ddeb5a01')
     version('1.18', sha256='46d188d102cbb414b4534e357e506c370644f2df8eada5565a2bcf234a282141')
     version('1.17.1', sha256='e778396dc6d9c106888c30bc11695a2283be68a5ced155df72cd5ec7d3c3f648')
 

--- a/packages/conformaltracking/package.py
+++ b/packages/conformaltracking/package.py
@@ -22,7 +22,8 @@ class Conformaltracking(CMakePackage, Ilcsoftpackage):
 
     version('master', branch='master')
     k4_add_latest_commit_as_version(git)
-    version('1.10',     sha256='7e0f5774a0ea80147b67db6c218de6001e83e46abc14396564a0a552725dbcce')
+    version('1.11',    sha256='297790748e211c7c8e52d70a283d6a9477ea0318db6c8521e640d41e4006520a')
+    version('1.10',    sha256='7e0f5774a0ea80147b67db6c218de6001e83e46abc14396564a0a552725dbcce')
     version('1.9',     sha256='c9ae5bd4f833b4542c8e2df01698c1a40ed8bdfc7330eb0e06ec9c3304b2bbca')
     version('1.8',     sha256='e25d2a5df0e77a4223120b0697e2c2414b6ffd12fe6f645c2fbb1a372b635c31')
     version('1.7',     sha256='d16da2af43d2556f870db725c205691b862c90c3d156e202faf2e232153bb3ec')

--- a/packages/ddmarlinpandora/package.py
+++ b/packages/ddmarlinpandora/package.py
@@ -18,6 +18,7 @@ class Ddmarlinpandora(CMakePackage, Ilcsoftpackage):
 
     version('master', branch='master')
     k4_add_latest_commit_as_version(git)
+    version('0.12', sha256='4f90c2ef240c2fa1f293498bf35201d1337651f8847d53da7124a61091bb504e')
     version('0.11', sha256='92410186209508091e0a8e330986283ffb32e40fd7195d10aad1a6a2e953f3ee')
 
     depends_on('ilcutil')

--- a/packages/ilcutil/package.py
+++ b/packages/ilcutil/package.py
@@ -17,19 +17,25 @@ class Ilcutil(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
+    version('1.6.2', sha256='2bb018f8cca4ca2480ba00c1f16100e62094fa6f9a0f07d2ba3a3dc274e32f3c')
     version('1.6.1', sha256='cb51f110c0c7b6e5732ab66d49b4658c56bb5944c1540f1563612ac56bb70823')
     version('1.6', sha256='09083890721704f39a3e902dc660db5326027cc38446b813233d04ec3233ba2e')
 
     patch("installdoc.patch", when="@:1.6.1")
 
     variant('cxxstd',
-            default='11',
+            default='17',
             values=('11', '14', '17'),
             multi=False,
             description='Use the specified C++ standard when building.')
 
+    variant('doc', default=False, description='Build the documentation')
+
+    depends_on("doxygen", when="+doc")
+
     def cmake_args(self):
         # C++ Standard
         return [
-            self.define_from_variant('CMAKE_CXX_STANDARD', 'cxxstd')
+            self.define_from_variant('CMAKE_CXX_STANDARD', 'cxxstd'),
+            self.define_from_variant('INSTALL_DOC', 'doc')
         ]

--- a/packages/lcgeo/package.py
+++ b/packages/lcgeo/package.py
@@ -18,6 +18,7 @@ class Lcgeo(CMakePackage, Ilcsoftpackage):
 
     version('master', branch='master')
     k4_add_latest_commit_as_version(git)
+    version('0.16.7', sha256='bde23af3c8dc695c4dcbb7460764c23e75dc534cd8a6170190e50a1a8083d45c')
     version('0.16.6', sha256='0eef7137ad69b771e5cf8a3f4a71e060e9d57ee825d8d944fa6a0dec8c2dad60')
     version('0.16.5', sha256='a46738b2479c0469b06584f82801bf2dd546623180300753de0b5684abd12a05')
 

--- a/packages/lctuple/package.py
+++ b/packages/lctuple/package.py
@@ -18,6 +18,7 @@ class Lctuple(CMakePackage, Ilcsoftpackage):
 
     version('master', branch='master')
     k4_add_latest_commit_as_version(git)
+    version('1.13', sha256='35f2ff3d4b89a3fd7e87f6f5c9fec2178afec26ae8c89d30a5b0bcf113d2107f')
     version('1.12', sha256='e0e7c4c86f257027a7e9b1c42438087a7b0919964f9719080be25df8a0f95968')
 
 

--- a/packages/marlinreco/package.py
+++ b/packages/marlinreco/package.py
@@ -18,6 +18,7 @@ class Marlinreco(CMakePackage, Ilcsoftpackage):
 
     version('master', branch='master')
     k4_add_latest_commit_as_version(git)
+    version('1.32', sha256='0ea3bee03e2bec1924b5876675043b592a942bc8cf306eb7056eaf03ac1748f6')
     version('1.31', sha256='eeb823f2476e1d31a54997b1a09fcc20cc8f3555a9f677054eacd5f44d4f59ee')
     version('1.30', sha256='e3b22a3f974232e4cc785326ad0dfd283b377cffda3245166f419b170276b6ff')
     version('1.29', sha256='45a36bb98f26580c182848d73ef0423290f99eae380f0cb27eea48f4ef48e459')

--- a/packages/marlintrk/package.py
+++ b/packages/marlintrk/package.py
@@ -20,6 +20,7 @@ class Marlintrk(CMakePackage):
 
     version('master', branch='master')
     k4_add_latest_commit_as_version(git)
+    version('2.9',     sha256='a1ccec25aea02d62f22d98cffc870ac199e455aa31100b6fa8795a8dc34cdcc0')
     version('2.8',     sha256='bd3b0074c06e2b778c74d1aeb2c989c39100a8adf5018792db599f84cb946c14')
     version('2.7',     sha256='c6e556d18ae6f2f3ae6c0fd8aa4322ce866e08b54b48ce95d09636443eff53ea')
     version('2.6',     sha256='a7be303a775eeb1a7b91f17710669878da9a6d4cca16aed1d251e63a8885c7fd')

--- a/packages/marlintrkprocessors/package.py
+++ b/packages/marlintrkprocessors/package.py
@@ -19,6 +19,7 @@ class Marlintrkprocessors(CMakePackage, Ilcsoftpackage):
 
     version('master', branch='master')
     k4_add_latest_commit_as_version(git)
+    version('2.12', sha256='ac1a3af380c837868649c8b7767e7641d25a1ecf40690726d55a9bcc58a54640')
     version('2.11', sha256='49a567831e2b7a0c43ded955ce31fbe7d467a59960f4bcc2c2120e20762639b0')
 
     depends_on('marlin')

--- a/packages/marlinutil/package.py
+++ b/packages/marlinutil/package.py
@@ -21,6 +21,7 @@ class Marlinutil(CMakePackage, Ilcsoftpackage):
 
     version('master', branch='master')
     k4_add_latest_commit_as_version(git)
+    version('1.16.1', sha256='f8e03cba4144b9797fa01321aeb1c2f01967d1fcb10089e7b1765c32e4346508')
     version('1.16', sha256='7f80a726e3b08653a88487b87618fca277d59fe22a448ce15043f8495f1108e9')
     version('1.15.1',  sha256='05e878c9aae4a675e37ad2c63abc0b1c4c2a45dcb2e3c9ae5c31e7e6f64118bf')
 

--- a/packages/overlay/package.py
+++ b/packages/overlay/package.py
@@ -18,6 +18,7 @@ class Overlay(CMakePackage, Ilcsoftpackage):
 
     version('master', branch='master')
     k4_add_latest_commit_as_version(git)
+    version('0.22.3', sha256='4a26b407a9275735c6ae156fdf073cbc6ea820e474d8e5ccc051753429a01ae1')
     version('0.22.2', sha256='305bdf568dc5fd221d6bd5d499cc25f7c567cc3ae21ff2954409a66549e4150f')
     version('0.22.1',   sha256='2f3ca472fe6aae44cdae0553f0e65b3c086a0d887d9cf53fd19468fb6107155b')
     version('0.22',     sha256='fa03e2870b8f072fd9c1cd68354274437050ce6ed30d0db9a816a3cbdee54cb1')


### PR DESCRIPTION
BEGINRELEASENOTES
- Add latest package versions for iLCSoft packages (v02-02-03 patch release, only missing: lcfiplus)

ENDRELEASENOTES
