### PR TITLE
larcontent: ignore clang errors due to unused-private-field

### DIFF
--- a/packages/larcontent/package.py
+++ b/packages/larcontent/package.py
@@ -40,7 +40,7 @@ class Larcontent(CMakePackage):
     def cmake_args(self):
         args = [
                 '-DCMAKE_MODULE_PATH=%s' % self.spec["pandorapfa"].prefix.cmakemodules,
-                "-DCMAKE_CXX_FLAGS=-std=c++17"]
+                "-DCMAKE_CXX_FLAGS=-std=c++17 -Wno-unused-private-field"]
         return args
 
     def url_for_version(self, version):


### PR DESCRIPTION
Only needed  for clang with the current master.  Seems to be due to the declaration of some variables that are only used inside a PANDORA_MONITORING_API macro, which then turns to a no-op.

BEGINRELEASENOTES
- larcontent: ignore clang errors due to unused-private-field

ENDRELEASENOTES
