### PR TITLE
Remove deprecated k4_add_latest commit macros

### DIFF
--- a/packages/aidatt/package.py
+++ b/packages/aidatt/package.py
@@ -3,8 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 class Aidatt(CMakePackage, Ilcsoftpackage):
     """Tracking toolkit developed in the AIDA project."""
@@ -16,7 +15,6 @@ class Aidatt(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
-    k4_add_latest_commit_as_version(git)
     version('0.10',     sha256='5379a369ee29bebeece7e814c0595bac9f08f2737ce03ae529b4b4e84dea1283')
 
     depends_on('ilcutil')

--- a/packages/babayaga/package.py
+++ b/packages/babayaga/package.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 import os
 
 

--- a/packages/bhlumi/package.py
+++ b/packages/bhlumi/package.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 import os
 
 

--- a/packages/ced/package.py
+++ b/packages/ced/package.py
@@ -4,8 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 
 class Ced(CMakePackage, Ilcsoftpackage):
@@ -18,7 +17,6 @@ class Ced(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
-    k4_add_latest_commit_as_version(git)
     version('1.9.3', sha256='60addba214b3d2ad65a3aacdcfc7d02fe697da0f3aefb0f6229370f08280ed3d')
     version('1.9.2', sha256='39a0cce64af74b915c128dcad5f4c91c634b1d35d646405aff0b72c6491f6161')
     version('1.9.1', sha256='62fd4265c57918a8b9891a033fd5f10f868dc52a068233e0325f7892cf1c1fd0')

--- a/packages/cedviewer/package.py
+++ b/packages/cedviewer/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 class Cedviewer(CMakePackage, Ilcsoftpackage):

--- a/packages/cepcsw/package.py
+++ b/packages/cepcsw/package.py
@@ -1,7 +1,6 @@
 # ----------------------------------------------------------------------------
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Key4hepPackage, k4_add_latest_commit_as_version 
+from spack.pkg.k4.key4hep_stack import Key4hepPackage 
 
 
 class Cepcsw(CMakePackage, Key4hepPackage):
@@ -20,7 +19,6 @@ class Cepcsw(CMakePackage, Key4hepPackage):
             multi=False,
             description='Use the specified C++ standard when building.')
 
-    k4_add_latest_commit_as_version(git)
     version('master', branch='master')
     version('0.1.1', sha256='0d56c2e63c0d91a64854c44ab4c0575fb0646cb566113721e3f35aee24e6a334')
     version('0.1.2', sha256='2caaf0723fa2561e97eb303e245b6a5e25185d4195b48c6a30dcc8d315951f42')

--- a/packages/clicperformance/package.py
+++ b/packages/clicperformance/package.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 

--- a/packages/clupatra/package.py
+++ b/packages/clupatra/package.py
@@ -4,8 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 
 class Clupatra(CMakePackage, Ilcsoftpackage):
@@ -18,7 +17,6 @@ class Clupatra(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
-    k4_add_latest_commit_as_version(git)
     version('1.3', sha256='5256d1b120157e9a6916f86249e589d0ea386c4e6dac83fec0294b753a779c25')
 
     depends_on('ilcutil')

--- a/packages/conddbmysql/package.py
+++ b/packages/conddbmysql/package.py
@@ -3,8 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Key4hepPackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Key4hepPackage
 
 
 class Conddbmysql(CMakePackage, Key4hepPackage):
@@ -17,7 +16,6 @@ class Conddbmysql(CMakePackage, Key4hepPackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
-    k4_add_latest_commit_as_version(git)
     version('0-9-7', sha256='7cbf9e06e2b3d131939ac0b66816814738e8c5021449f19921b4071c1979ef5a')
 
 

--- a/packages/conformaltracking/package.py
+++ b/packages/conformaltracking/package.py
@@ -4,8 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 
 class Conformaltracking(CMakePackage, Ilcsoftpackage):
@@ -21,7 +20,6 @@ class Conformaltracking(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
-    k4_add_latest_commit_as_version(git)
     version('1.11',    sha256='297790748e211c7c8e52d70a283d6a9477ea0318db6c8521e640d41e4006520a')
     version('1.10',    sha256='7e0f5774a0ea80147b67db6c218de6001e83e46abc14396564a0a552725dbcce')
     version('1.9',     sha256='c9ae5bd4f833b4542c8e2df01698c1a40ed8bdfc7330eb0e06ec9c3304b2bbca')

--- a/packages/dag/package.py
+++ b/packages/dag/package.py
@@ -1,4 +1,3 @@
-from spack import *
 
 
 class Dag(CMakePackage):

--- a/packages/ddkaltest/package.py
+++ b/packages/ddkaltest/package.py
@@ -4,8 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 
 class Ddkaltest(CMakePackage, Ilcsoftpackage):
@@ -18,7 +17,6 @@ class Ddkaltest(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
-    k4_add_latest_commit_as_version(git)
     version('1.6',     sha256='e668242d84eb94e59edca18e524b1a928fcf7ae7c4b79f76f0338a0a4e835d8f')
     version('1.5',     sha256='4ef6fea7527dbb5f9a12322e92e27d80f2c29b115aae13987f55cb6cf02f31f5')
     version('1.4',     sha256='c5cefd23366c47087a6b04b5d48ab28ac88e8855446d782cfb8a954088fd4207')

--- a/packages/ddmarlinpandora/package.py
+++ b/packages/ddmarlinpandora/package.py
@@ -3,8 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 
 class Ddmarlinpandora(CMakePackage, Ilcsoftpackage):
@@ -17,7 +16,6 @@ class Ddmarlinpandora(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
-    k4_add_latest_commit_as_version(git)
     version('0.12', sha256='4f90c2ef240c2fa1f293498bf35201d1337651f8847d53da7124a61091bb504e')
     version('0.11', sha256='92410186209508091e0a8e330986283ffb32e40fd7195d10aad1a6a2e953f3ee')
 

--- a/packages/dual-readout/package.py
+++ b/packages/dual-readout/package.py
@@ -4,8 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Key4hepPackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Key4hepPackage
 
 
 class DualReadout(CMakePackage, Key4hepPackage):
@@ -18,7 +17,6 @@ class DualReadout(CMakePackage, Key4hepPackage):
     maintainers = ['vvolkl', 'SanghyunKo']
 
     version('master', branch='master') 
-    k4_add_latest_commit_as_version(git)
     version('0.0.3', sha256='d35e7193c11385505494f11328d54a595b3ff953563bae06b8954c1ef24209b3')
     version('0.0.2', sha256='f76c1febf3d8e29d5287ba03eacbc244f8c615502295f7471579245376da91ad')
 

--- a/packages/fcalclusterer/package.py
+++ b/packages/fcalclusterer/package.py
@@ -3,8 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 
 class Fcalclusterer(CMakePackage, Ilcsoftpackage):
@@ -17,7 +16,6 @@ class Fcalclusterer(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
-    k4_add_latest_commit_as_version(git)
     version('1.0.3', sha256='5360ccb85f8742d9f4b84c7a3bb3ed3574b534f1b08240100c5b4e48e8ffa35e')
     version('1.0.2', sha256='6c6898f8641743a7654b1c1e7b3a52643be9d23f8bb3624e415c51549ac64cbe')
     version('1.0.1', sha256='87837d7fd802e46c8530c721035ae75946d699031f093612ec02a7fabe0c6143')

--- a/packages/fcc-edm/package.py
+++ b/packages/fcc-edm/package.py
@@ -1,6 +1,5 @@
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Key4hepPackage, k4_add_latest_commit_as_version 
+from spack.pkg.k4.key4hep_stack import Key4hepPackage 
 
 class FccEdm(CMakePackage, Key4hepPackage):
     """Event data model of FCC"""

--- a/packages/fccdetectors/package.py
+++ b/packages/fccdetectors/package.py
@@ -1,6 +1,5 @@
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Key4hepPackage, k4_add_latest_commit_as_version 
+from spack.pkg.k4.key4hep_stack import Key4hepPackage 
 
 class Fccdetectors(CMakePackage, Key4hepPackage):
     """FCC Detector Descriptions"""

--- a/packages/fccsw/package.py
+++ b/packages/fccsw/package.py
@@ -1,6 +1,5 @@
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Key4hepPackage, k4_add_latest_commit_as_version 
+from spack.pkg.k4.key4hep_stack import Key4hepPackage 
 
 class Fccsw(CMakePackage, Key4hepPackage):
     """Software framework of the FCC project"""

--- a/packages/forwardtracking/package.py
+++ b/packages/forwardtracking/package.py
@@ -3,8 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 
 class Forwardtracking(CMakePackage, Ilcsoftpackage):
@@ -17,7 +16,6 @@ class Forwardtracking(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
-    k4_add_latest_commit_as_version(git)
     version('1.14', sha256='99149d170a1ae179500b2c47ec79dca227ff96c0bdf0cd69f2075eb468177a5e')
 
     patch('testing.patch', when="@:1.15")

--- a/packages/garlic/package.py
+++ b/packages/garlic/package.py
@@ -4,8 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 
 class Garlic(CMakePackage, Ilcsoftpackage):
@@ -18,7 +17,6 @@ class Garlic(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
-    k4_add_latest_commit_as_version(git)
     version('3.1', sha256='a35bea352d0c6aaa7d289656f6272be216e9b8ada2a750461ceed7c2cf780940')
 
     depends_on('ilcutil')

--- a/packages/gear/package.py
+++ b/packages/gear/package.py
@@ -3,8 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 
 class Gear(CMakePackage, Ilcsoftpackage):
@@ -17,7 +16,6 @@ class Gear(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
-    k4_add_latest_commit_as_version(git)
     version('1.9.0', sha256='18564d50bc4863441bd4b5b72dda565065f8b7f5821e30c804c7e93c7afe84ae')
 
     patch("build_testing.patch", when="@1.9.0")

--- a/packages/generalbrokenlines/package.py
+++ b/packages/generalbrokenlines/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack import *
 
 
 class Generalbrokenlines(CMakePackage):

--- a/packages/guinea-pig/package.py
+++ b/packages/guinea-pig/package.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 
 
 class GuineaPig(CMakePackage):

--- a/packages/ilcsoft/package.py
+++ b/packages/ilcsoft/package.py
@@ -48,7 +48,6 @@ class Ilcsoft(BundlePackage, Key4hepPackage):
     depends_on("k4lcioreader")
 
     depends_on("k4simdelphes")
-				 giturl="https://api.github.com/repos/%s/commits/main")
 
     depends_on("delphes")
 

--- a/packages/ilcsoft/package.py
+++ b/packages/ilcsoft/package.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
-from spack.pkg.k4.key4hep_stack import Key4hepPackage, k4_add_latest_commit_as_dependency, install_setup_script
+from spack.pkg.k4.key4hep_stack import Key4hepPackage
+from spack.pkg.k4.key4hep_stack import install_setup_script
 
 
 class Ilcsoft(BundlePackage, Key4hepPackage):
@@ -11,8 +12,6 @@ class Ilcsoft(BundlePackage, Key4hepPackage):
     ##################### versions ########################
     #######################################################
     ###  nightly builds
-    # builds the HEAD of each package for which 
-    # k4_add_latest_commit_as_dependency is called below
     version('master')
     # this version can be extended with additional version
     # fields to differentiate it, like 'master-2020-10-10'
@@ -47,147 +46,101 @@ class Ilcsoft(BundlePackage, Key4hepPackage):
     #depends_on('whizard@master +lcio +openloops hepmc=2', when="@master")
 
     depends_on("k4lcioreader")
-    k4_add_latest_commit_as_dependency("k4lcioreader", "key4hep/k4LCIOReader", when="@master")
 
     depends_on("k4simdelphes")
-    k4_add_latest_commit_as_dependency("k4simdelphes", "key4hep/k4SimDelphes", when="@master",
 				 giturl="https://api.github.com/repos/%s/commits/main")
 
     depends_on("delphes")
-    k4_add_latest_commit_as_dependency("delphes", "delphes/delphes", when="@master")
 
 
     ############################### ilcsoft ###############
     #######################################################
     depends_on('aidatt')
-    k4_add_latest_commit_as_dependency("aidatt", "aidasoft/aidatt", when="@master")
 
     depends_on('cedviewer')
-    k4_add_latest_commit_as_dependency("cedviewer", "ilcsoft/cedviewer", when="@master")
 
     depends_on('conformaltracking')
-    k4_add_latest_commit_as_dependency("conformaltracking", "ilcsoft/conformaltracking", when="@master")
 
     depends_on('clicperformance')
-    k4_add_latest_commit_as_dependency("clicperformance", "ilcsoft/clicperformance", when="@master")
 
     depends_on('clupatra')
-    k4_add_latest_commit_as_dependency("clupatra", "ilcsoft/clupatra", when="@master")
 
     depends_on('ced')
-    k4_add_latest_commit_as_dependency("ced", "ilcsoft/ced", when="@master")
 
     depends_on('ddkaltest')
-    k4_add_latest_commit_as_dependency("ddkaltest", "ilcsoft/ddkaltest", when="@master")
 
     depends_on('ddmarlinpandora')
-    k4_add_latest_commit_as_dependency("ddmarlinpandora", "ilcsoft/ddmarlinpandora", when="@master")
 
     depends_on('fcalclusterer')
-    k4_add_latest_commit_as_dependency("fcalclusterer", "fcalsw/fcalclusterer", when="@master")
 
     depends_on('forwardtracking')
-    k4_add_latest_commit_as_dependency("forwardtracking", "ilcsoft/forwardtracking", when="@master")
 
     depends_on('garlic')
-    k4_add_latest_commit_as_dependency("garlic", "ilcsoft/garlic", when="@master")
 
     depends_on('k4marlinwrapper')
-    k4_add_latest_commit_as_dependency("k4marlinwrapper", "key4hep/k4marlinwrapper", when="@master")
 
     depends_on('generalbrokenlines')
-    k4_add_latest_commit_as_dependency("generalbrokenlines", "GeneralBrokenLines/GeneralBrokenLines", when="@master")
 
     depends_on('gear')
-    k4_add_latest_commit_as_dependency("gear", "ilcsoft/gear", when="@master")
 
     depends_on('ilcutil')
-    k4_add_latest_commit_as_dependency("ilcutil", "ilcsoft/ilcutil", when="@master")
 
     depends_on('ildperformance')
-    k4_add_latest_commit_as_dependency("ildperformance", "ilcsoft/ildperformance", when="@master")
 
     depends_on('kaldet')
-    k4_add_latest_commit_as_dependency("kaldet", "ilcsoft/kaldet", when="@master")
 
     depends_on('kitrackmarlin')
-    k4_add_latest_commit_as_dependency("kitrackmarlin", "ilcsoft/kitrackmarlin", when="@master")
 
     depends_on('kaltest')
-    k4_add_latest_commit_as_dependency("kaltest", "ilcsoft/kaltest", when="@master")
 
     depends_on('kitrack')
-    k4_add_latest_commit_as_dependency("kitrack", "ilcsoft/kitrack", when="@master")
 
     depends_on('lcfiplus')
-    k4_add_latest_commit_as_dependency("lcfiplus", "lcfiplus/lcfiplus", when="@master")
 
     depends_on('lctuple')
-    k4_add_latest_commit_as_dependency("lctuple", "ilcsoft/lctuple", when="@master")
 
     depends_on('lcfivertex')
-    k4_add_latest_commit_as_dependency("lcfivertex", "ilcsoft/lcfivertex", when="@master")
 
     depends_on('lich')
-    k4_add_latest_commit_as_dependency("lich", "danerdaner/lich", when="@master")
 
     depends_on('lccd')
-    k4_add_latest_commit_as_dependency("lccd", "ilcsoft/lccd", when="@master")
 
     depends_on('lcio')
-    k4_add_latest_commit_as_dependency("lcio", "ilcsoft/lcio", when="@master")
 
     depends_on('lcgeo')
-    k4_add_latest_commit_as_dependency("lcgeo", "ilcsoft/lcgeo", when="@master")
 
     depends_on('marlin')
-    k4_add_latest_commit_as_dependency("marlin", "ilcsoft/marlin", when="@master")
 
     depends_on('marlinutil')
-    k4_add_latest_commit_as_dependency("marlinutil", "ilcsoft/marlinutil", when="@master")
 
     depends_on('marlinpandora')
-    k4_add_latest_commit_as_dependency("marlinpandora", "pandorapfa/marlinpandora", when="@master")
 
     depends_on("marlindd4hep")
-    k4_add_latest_commit_as_dependency("marlindd4hep", "ilcsoft/marlindd4hep", when="@master")
 
     depends_on('marlinreco')
-    k4_add_latest_commit_as_dependency("marlinreco", "ilcsoft/marlinreco", when="@master")
 
     depends_on('marlinfastjet')
-    k4_add_latest_commit_as_dependency("marlinfastjet", "ilcsoft/marlinfastjet", when="@master")
 
     depends_on('marlinkinfit')
-    k4_add_latest_commit_as_dependency("marlinkinfit", "ilcsoft/marlinkinfit", when="@master")
 
     depends_on('marlinkinfitprocessors')
-    k4_add_latest_commit_as_dependency('marlinkinfitprocessors', 'ilcsoft/marlinkinfitprocessors', when='@master')
 
     depends_on('marlintrkprocessors')
-    k4_add_latest_commit_as_dependency("marlintrkprocessors", "ilcsoft/marlintrkprocessors", when="@master")
 
     depends_on('marlintrk')
-    k4_add_latest_commit_as_dependency("marlintrk", "ilcsoft/marlintrk", when="@master")
 
     depends_on('overlay')
-    k4_add_latest_commit_as_dependency("overlay", "ilcsoft/overlay", when="@master")
 
     depends_on('pandoraanalysis')
-    k4_add_latest_commit_as_dependency("pandoraanalysis", "PandoraPFA/LCPandoraAnalysis", when="@master")
 
     depends_on('pandorapfa')
-    #k4_add_latest_commit_as_dependency("pandorapfa", "pandorapfa/pandorapfa", when="@master")
 
 
     depends_on('physsim')
-    k4_add_latest_commit_as_dependency("physsim", "ilcsoft/physsim", when="@master")
 
     depends_on("raida")
-    k4_add_latest_commit_as_dependency("raida", "ilcsoft/raida", when="@master")
 
     depends_on('sio')
-    k4_add_latest_commit_as_dependency("sio", "ilcsoft/sio", when="@master")
 
 
 

--- a/packages/ilcutil/package.py
+++ b/packages/ilcutil/package.py
@@ -3,8 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 
 class Ilcutil(CMakePackage, Ilcsoftpackage):

--- a/packages/ildperformance/package.py
+++ b/packages/ildperformance/package.py
@@ -3,8 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 
 class Ildperformance(CMakePackage, Ilcsoftpackage):
@@ -17,7 +16,6 @@ class Ildperformance(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
-    k4_add_latest_commit_as_version(git)
     version('1.10', sha256='5dc9b20af8018d2268df02d05a7245ca8087365a404fd9c3a110484235f7d383')
     version('1.9', sha256='3a8187036eee39b35e4a58d874fa906182a7b83e1d143811ec7d721ea405f3dc')
     version('1.8', sha256='bcf19d3a6f425fa5eea228676d07558635881a0329c4d66ffda4230dfe9617c1')

--- a/packages/k4actstracking/package.py
+++ b/packages/k4actstracking/package.py
@@ -1,5 +1,4 @@
 
-from spack import *
 from spack.pkg.k4.key4hep_stack import Key4hepPackage
 
 class K4actstracking(BundlePackage, Key4hepPackage):

--- a/packages/k4clue/package.py
+++ b/packages/k4clue/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack import *
 from spack.pkg.k4.key4hep_stack import Key4hepPackage
 
 

--- a/packages/k4fwcore/package.py
+++ b/packages/k4fwcore/package.py
@@ -1,5 +1,4 @@
-from spack import *
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 
 class K4fwcore(CMakePackage, Ilcsoftpackage):
@@ -9,7 +8,6 @@ class K4fwcore(CMakePackage, Ilcsoftpackage):
     git = "https://github.com/key4hep/k4FWCore.git"
 
     version('master', branch='master')
-    k4_add_latest_commit_as_version(git)
     version('1.0pre12', tag="v01-00pre12") 
     version('0.2.0', sha256='7d1a6e7494f08c2b25901cab2138795f21b6c4e84f05c4f8b9a6839787874b72')
     version('0.1.1', sha256='9c4e4b487f7d9c982547c13570345399505e763fb369b76ceadb35c1d52bf6aa')

--- a/packages/k4gen/package.py
+++ b/packages/k4gen/package.py
@@ -1,6 +1,5 @@
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Key4hepPackage, k4_add_latest_commit_as_version 
+from spack.pkg.k4.key4hep_stack import Key4hepPackage 
 
 class K4gen(CMakePackage, Key4hepPackage):
     """Generator components for the Key4hep framework"""

--- a/packages/k4lcioreader/package.py
+++ b/packages/k4lcioreader/package.py
@@ -1,6 +1,5 @@
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Key4hepPackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Key4hepPackage
 
 class K4lcioreader(CMakePackage, Key4hepPackage):
     """LCIO reader based on PODIO and EDM4hep"""

--- a/packages/k4marlinwrapper/package.py
+++ b/packages/k4marlinwrapper/package.py
@@ -3,8 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 class K4marlinwrapper(CMakePackage, Ilcsoftpackage):
     """Gaudify Marlin Processors in order to run them in the Key4HEP framework"""
@@ -16,7 +15,6 @@ class K4marlinwrapper(CMakePackage, Ilcsoftpackage):
     maintainers = ['fdplacido']
 
     version('master', branch='master')
-    k4_add_latest_commit_as_version(git)
     version('0.4', sha256='6609dacb158f8fd2f8532e0881b0acb73ea23f31578eab44085876a8a59a5946')
     version('0.3.1',  sha256='a8ef66f6500b9a709b950cdfd3bcb0c775d7fa42336b2aa5c80e2efef7c95b19')
     version('0.3',    sha256='381fd96e2ede03bec048afaeef13b8efffe80030fc097fe18fae62b03c0fba94')

--- a/packages/k4pandora/package.py
+++ b/packages/k4pandora/package.py
@@ -3,8 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Key4hepPackage, k4_add_latest_commit_as_version 
+from spack.pkg.k4.key4hep_stack import Key4hepPackage 
 
 
 class K4pandora(CMakePackage, Key4hepPackage):
@@ -24,7 +23,6 @@ class K4pandora(CMakePackage, Key4hepPackage):
             multi=False,
             description='Use the specified C++ standard when building.')
 
-    k4_add_latest_commit_as_version(git)
     version('master', branch='master')
 
     depends_on('clhep')

--- a/packages/k4projecttemplate/package.py
+++ b/packages/k4projecttemplate/package.py
@@ -1,5 +1,4 @@
 
-from spack import *
 from spack.pkg.k4.key4hep_stack import Key4hepPackage
 
 class K4projecttemplate(CMakePackage, Key4hepPackage):

--- a/packages/k4reccalorimeter/package.py
+++ b/packages/k4reccalorimeter/package.py
@@ -1,6 +1,5 @@
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Key4hepPackage, k4_add_latest_commit_as_version 
+from spack.pkg.k4.key4hep_stack import Key4hepPackage 
 
 class K4reccalorimeter(CMakePackage, Key4hepPackage):
     """Calorimeter reconstruction components for the Key4hep framework"""

--- a/packages/k4simdelphes/package.py
+++ b/packages/k4simdelphes/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 class K4simdelphes(CMakePackage, Ilcsoftpackage):
     """EDM4HEP output for Delphes."""
@@ -15,7 +15,6 @@ class K4simdelphes(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('main', branch='main')
-    k4_add_latest_commit_as_version(git)
     version('00-01-07', sha256='e348317a11de78244e864968c343d408f6a70f2cad96f99823e856ae4be9ef3b')
     version('00-01-06', sha256='44072ee6fab87ea120481fce6838444467c3c8a00da0ddbfc51a663e119f8f27')
     version('00-01-05', sha256='49aa0942fd80bcef67386eb2a86d2b1bb4bdf2eeb6092c040d2d5c90e63feb3e')

--- a/packages/k4simgeant4/package.py
+++ b/packages/k4simgeant4/package.py
@@ -1,6 +1,5 @@
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Key4hepPackage, k4_add_latest_commit_as_version 
+from spack.pkg.k4.key4hep_stack import Key4hepPackage 
 
 class K4simgeant4(CMakePackage, Key4hepPackage):
     """Geant4 components of the Key4HEP software """

--- a/packages/kaldet/package.py
+++ b/packages/kaldet/package.py
@@ -4,8 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 
 class Kaldet(CMakePackage, Ilcsoftpackage):
@@ -18,7 +17,6 @@ class Kaldet(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
-    k4_add_latest_commit_as_version(git)
     version('1.14.1',  sha256='39386f8d9648ebfd9771d99f2d318c5214a5560ad4135a12b90b0f3662681e6d')
     version('1.14',     sha256='67eb70874f9cd1d85d0a192e40e3e2ec3ecd03b6e2746bb2e1bdcf1b40c9c32a')
     version('1.13',     sha256='3d299dae6622560881365acc5e9b572faefc39dbeee453562d0d9b9ab2795633')

--- a/packages/kaltest/package.py
+++ b/packages/kaltest/package.py
@@ -4,8 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 
 class Kaltest(CMakePackage, Ilcsoftpackage):
@@ -18,7 +17,6 @@ class Kaltest(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
-    k4_add_latest_commit_as_version(git)
     version('2.5',      sha256='8753ecf5ed7819744cc66a652cf8ddcd0d783a25ee19b5387212f70dd9abbce5')
     version('2.4',      sha256='8cd089a51c499cc807dda196150a3da124b4a2a192bcc6b2d55b9c8b5481e5d5')
     version('2.3',      sha256='fa09a8e4a29c18b7b7b094d5d675a70b15eca1a9871c64141bafb9da0b893d3e')

--- a/packages/key4hep-stack/common.py
+++ b/packages/key4hep-stack/common.py
@@ -108,18 +108,6 @@ def k4_lookup_latest_commit(repoinfo, giturl):
     test = int(commit, 16)
     return commit
 
-def k4_add_latest_commit_as_dependency(name, repoinfo, giturl="https://api.github.com/repos/%s/commits/master", variants="", when="@master"):
-    """ Helper function that adds a 'depends_on' with the latest commit to a spack recipe. [DEPRECATED]
-
-    """
-    pass
-
-def k4_add_latest_commit_as_version(git_url, git_api_url="https://api.github.com/repos/%s/commits/master"):
-    """ Helper function that adds a 'version' with the latest commit to a spack recipe. [DEPRECATED]
-    """
-    pass
-
-
 
 def ilc_url_for_version(self, version):
     """Translate version numbers to ilcsoft conventions.

--- a/packages/key4hep-stack/common.py
+++ b/packages/key4hep-stack/common.py
@@ -76,37 +76,6 @@ def k4_generate_setup_script(env_mod, shell='sh'):
                 name, cmd_quote(new_env[name]))]
     return ''.join(cmds)
 
-def k4_lookup_latest_commit(repoinfo, giturl):
-    """Use a github-like api to fetch the commit hash of the master branch.
-    Constructs and runs a command of the form:
-    # curl -s -u user:usertoken https://api.github.com/repos/hep-fcc/fccsw/commits/master -H "Accept: application/vnd.github.VERSION.sha"
-    The authentication is optional, but note that the api might be rate-limited quite strictly for unauthenticated access.
-    The envrionment variables 
-      GITHUB_USER
-      GITHUB_TOKEN
-    can be used for authentication.
-
-    :param repoinfo: description of the owner and repository names, p.ex: "key4hep/edm4hep"
-    :type repoinfo: str
-    :param giturl: url that will return a json response with the commit sha when queried with urllib.
-       should contain a %s which will be substituted by repoinfo.
-       p.ex.: "https://api.github.com/repos/%s/commits/master"
-    :return: The commit sha of the latest commit for the repo.
-    :rtype: str
-      
-    """
-    curl_command = ["curl -s "]
-    github_user = os.environ.get("GITHUB_USER", "")
-    github_token = os.environ.get("GITHUB_TOKEN", "")
-    if github_user and github_token:
-      curl_command += [" -u %s:%s " % (github_user, github_token)]
-    final_giturl = giturl % repoinfo
-    curl_command += [final_giturl]
-    curl_command += [' -H "Accept: application/vnd.github.VERSION.sha" ']
-    curl_command = ' '.join(curl_command)
-    commit = os.popen(curl_command).read()
-    test = int(commit, 16)
-    return commit
 
 
 def ilc_url_for_version(self, version):

--- a/packages/key4hep-stack/package.py
+++ b/packages/key4hep-stack/package.py
@@ -63,13 +63,10 @@ class Key4hepStack(BundlePackage, Key4hepPackage):
 
 
     depends_on("k4simdelphes")
-				 giturl="https://api.github.com/repos/%s/commits/main")
 
     depends_on("k4gen")
-				 giturl="https://api.github.com/repos/%s/commits/main")
 
     depends_on("k4simgeant4")
-				 giturl="https://api.github.com/repos/%s/commits/main")
 
     depends_on("k4clue")
 
@@ -118,10 +115,8 @@ class Key4hepStack(BundlePackage, Key4hepPackage):
     depends_on("fccanalyses")
 
     depends_on("fccdetectors")
-				 giturl="https://api.github.com/repos/%s/commits/main")
 
     depends_on("k4reccalorimeter")
-				 giturl="https://api.github.com/repos/%s/commits/main")
 
     ############################## cepcsw #################
     #######################################################

--- a/packages/key4hep-stack/package.py
+++ b/packages/key4hep-stack/package.py
@@ -17,8 +17,6 @@ class Key4hepStack(BundlePackage, Key4hepPackage):
     ##################### versions ########################
     #######################################################
     ###  nightly builds
-    # builds the HEAD of each package for which 
-    # k4_add_latest_commit_as_dependency is called below
     version('master')
     # this version can be extended with additional version
     # fields to differentiate it, like 'master-2020-10-10'
@@ -53,36 +51,27 @@ class Key4hepStack(BundlePackage, Key4hepPackage):
     ##################### common key4hep packages #########
     #######################################################
     depends_on('edm4hep')
-    k4_add_latest_commit_as_dependency("edm4hep", "key4hep/edm4hep", when="@master")
 
     depends_on('podio')
     # TODO: temporarily disable due to known issue with https://github.com/AIDASoft/podio/pull/193
-    #k4_add_latest_commit_as_dependency("podio", "aidasoft/podio", when="@master")
 
     depends_on('dd4hep')
-    k4_add_latest_commit_as_dependency("dd4hep", "aidasoft/dd4hep", when="@master")
 
     depends_on("k4fwcore")
-    k4_add_latest_commit_as_dependency("k4fwcore", "key4hep/k4fwcore", when="@master")
 
     depends_on("k4projecttemplate")
-    k4_add_latest_commit_as_dependency("k4projecttemplate", "key4hep/k4-project-template", when="@master")
 
 
     depends_on("k4simdelphes")
-    k4_add_latest_commit_as_dependency("k4simdelphes", "key4hep/k4SimDelphes", when="@master",
 				 giturl="https://api.github.com/repos/%s/commits/main")
 
     depends_on("k4gen")
-    k4_add_latest_commit_as_dependency("k4gen", "hep-fcc/k4Gen", when="@master",
 				 giturl="https://api.github.com/repos/%s/commits/main")
 
     depends_on("k4simgeant4")
-    k4_add_latest_commit_as_dependency("k4simgeant4", "hep-fcc/k4simgeant4", when="@master",
 				 giturl="https://api.github.com/repos/%s/commits/main")
 
     depends_on("k4clue")
-    k4_add_latest_commit_as_dependency("k4clue", "key4hep/k4clue", when="@master")
 
     depends_on('k4actstracking')
 
@@ -102,7 +91,6 @@ class Key4hepStack(BundlePackage, Key4hepPackage):
 
     depends_on("delphes")
     # wait for issues in delphes master to be fixed
-    k4_add_latest_commit_as_dependency("delphes", "delphes/delphes", when="@master")
 
     ##################### general purpose generators ######
     #######################################################
@@ -122,31 +110,24 @@ class Key4hepStack(BundlePackage, Key4hepPackage):
     ############################### fccsw #################
     #######################################################
     depends_on("fccsw")
-    k4_add_latest_commit_as_dependency("fccsw", "hep-fcc/fccsw", when="@master")
 
 
     #depends_on("dual-readout")
-    #k4_add_latest_commit_as_dependency("dual-readout", "hep-fcc/dual-readout", when="@master")
 
 
     depends_on("fccanalyses")
-    k4_add_latest_commit_as_dependency("fccanalyses", "hep-fcc/fccanalyses", when="@master")
 
     depends_on("fccdetectors")
-    k4_add_latest_commit_as_dependency("fccdetectors", "hep-fcc/fccdetectors", when="@master",
 				 giturl="https://api.github.com/repos/%s/commits/main")
 
     depends_on("k4reccalorimeter")
-    k4_add_latest_commit_as_dependency("k4reccalorimeter", "hep-fcc/k4reccalorimeter", when="@master",
 				 giturl="https://api.github.com/repos/%s/commits/main")
 
     ############################## cepcsw #################
     #######################################################
     depends_on("cepcsw")
-    k4_add_latest_commit_as_dependency("cepcsw", "cepc/cepcsw", when="@master")
     
     depends_on("k4lcioreader")
-    k4_add_latest_commit_as_dependency("k4lcioreader", "key4hep/k4LCIOReader", when="@master")
 
 
     ##################### developer tools #################

--- a/packages/kitrack/package.py
+++ b/packages/kitrack/package.py
@@ -4,8 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 
 class Kitrack(CMakePackage, Ilcsoftpackage):
@@ -18,7 +17,6 @@ class Kitrack(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
-    k4_add_latest_commit_as_version(git)
     version('1.10', sha256='e89e0553ba76946749e422aa470bbe20456b085efe523fb42f97565201376870')
 
     depends_on('ilcutil')

--- a/packages/kitrackmarlin/package.py
+++ b/packages/kitrackmarlin/package.py
@@ -4,8 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 
 class Kitrackmarlin(CMakePackage, Ilcsoftpackage):
@@ -18,7 +17,6 @@ class Kitrackmarlin(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
-    k4_add_latest_commit_as_version(git)
     version('1.13', sha256='1307578313673fae159aa6fb4eacf3f22bfa085c61337d14a5895e078a8d7f70')
 
     depends_on('kitrack')

--- a/packages/kkmcee/package.py
+++ b/packages/kkmcee/package.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 import os
 
 

--- a/packages/larcontent/package.py
+++ b/packages/larcontent/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack import *
 
 
 class Larcontent(CMakePackage):

--- a/packages/lccd/package.py
+++ b/packages/lccd/package.py
@@ -3,8 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 
 class Lccd(CMakePackage, Ilcsoftpackage):
@@ -17,7 +16,6 @@ class Lccd(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
-    k4_add_latest_commit_as_version(git)
     version('1.5.0', sha256='876f751bebab760303b8dc3b7c6d4fe7d47ddd5aa19af9338f6565c5b817229b')
 
     variant('conddbmysql', default=False,

--- a/packages/lccontent/package.py
+++ b/packages/lccontent/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack import *
 
 
 class Lccontent(CMakePackage):

--- a/packages/lcfiplus/package.py
+++ b/packages/lcfiplus/package.py
@@ -4,8 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 
 class Lcfiplus(CMakePackage, Ilcsoftpackage):
@@ -18,7 +17,6 @@ class Lcfiplus(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
-    k4_add_latest_commit_as_version(git)
     version('0.10',       sha256='0d4d27cd0d9407cd2f13e5a978be8c9389bc86c78c2eefd0ae7c060c4b7196c3')
 
     depends_on('marlin')

--- a/packages/lcfivertex/package.py
+++ b/packages/lcfivertex/package.py
@@ -3,8 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 
 class Lcfivertex(CMakePackage, Ilcsoftpackage):
@@ -17,7 +16,6 @@ class Lcfivertex(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
     
     version('master',  branch='master')
-    k4_add_latest_commit_as_version(git)
     version('0.8', sha256='37f3ea8754cefb60073471c298b4c1926ef9858e8edb4c51affa1ff7de4e2fb8')
 
     depends_on('lcio')

--- a/packages/lcgeo/package.py
+++ b/packages/lcgeo/package.py
@@ -3,8 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 
 class Lcgeo(CMakePackage, Ilcsoftpackage):
@@ -17,7 +16,6 @@ class Lcgeo(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
-    k4_add_latest_commit_as_version(git)
     version('0.16.7', sha256='bde23af3c8dc695c4dcbb7460764c23e75dc534cd8a6170190e50a1a8083d45c')
     version('0.16.6', sha256='0eef7137ad69b771e5cf8a3f4a71e060e9d57ee825d8d944fa6a0dec8c2dad60')
     version('0.16.5', sha256='a46738b2479c0469b06584f82801bf2dd546623180300753de0b5684abd12a05')

--- a/packages/lctuple/package.py
+++ b/packages/lctuple/package.py
@@ -3,8 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 
 class Lctuple(CMakePackage, Ilcsoftpackage):
@@ -17,7 +16,6 @@ class Lctuple(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
-    k4_add_latest_commit_as_version(git)
     version('1.13', sha256='35f2ff3d4b89a3fd7e87f6f5c9fec2178afec26ae8c89d30a5b0bcf113d2107f')
     version('1.12', sha256='e0e7c4c86f257027a7e9b1c42438087a7b0919964f9719080be25df8a0f95968')
 

--- a/packages/lich/package.py
+++ b/packages/lich/package.py
@@ -4,8 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 
 class Lich(CMakePackage, Ilcsoftpackage):
@@ -20,7 +19,6 @@ class Lich(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
-    k4_add_latest_commit_as_version(git)
     version('0.1', sha256='9c5358f76c64b9f28734b82cca31101e09faa67b6ffd340889488c761aea918c')
 
     depends_on('ilcutil')

--- a/packages/marlin/package.py
+++ b/packages/marlin/package.py
@@ -3,8 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 
 class Marlin(CMakePackage, Ilcsoftpackage):
@@ -17,7 +16,6 @@ class Marlin(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
-    k4_add_latest_commit_as_version(git)
     version('1.17.1', sha256='b928c6072bbf8db5fdb3b9716227b8724dfc90182967212cd9f2f51ceb760dd0')
     version('1.17', sha256='076acc3a91b7e2e253f338395a8e56bf00498e6aa1a118d3e7bde84f1065d3d6')
 

--- a/packages/marlindd4hep/package.py
+++ b/packages/marlindd4hep/package.py
@@ -4,8 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 
 class Marlindd4hep(CMakePackage, Ilcsoftpackage):
@@ -18,7 +17,6 @@ class Marlindd4hep(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
-    k4_add_latest_commit_as_version(git)
     version('0.6', sha256='1cf8eb03bbdf6da8fbf277d8168d97f77e1675850a7e66d0e9f90684e3a2f077')
 
     depends_on('ilcutil')

--- a/packages/marlinfastjet/package.py
+++ b/packages/marlinfastjet/package.py
@@ -3,8 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 
 class Marlinfastjet(CMakePackage, Ilcsoftpackage):
@@ -17,7 +16,6 @@ class Marlinfastjet(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
-    k4_add_latest_commit_as_version(git)
     version('0.5.2', sha256='abdffa6c2c9328bb094456f6003920d0c860e7faa5c76aea650da9e47e698bdf')
 
 

--- a/packages/marlinkinfit/package.py
+++ b/packages/marlinkinfit/package.py
@@ -3,8 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 
 class Marlinkinfit(CMakePackage, Ilcsoftpackage):
@@ -17,7 +16,6 @@ class Marlinkinfit(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
-    k4_add_latest_commit_as_version(git)
     version('0.6', sha256='e22127f3d349c5b5a6a1c95585f5bf410d77cf598b3432b188f781436632372a')
 
     depends_on('ilcutil')

--- a/packages/marlinkinfitprocessors/package.py
+++ b/packages/marlinkinfitprocessors/package.py
@@ -3,8 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 
 class Marlinkinfitprocessors(CMakePackage, Ilcsoftpackage):
@@ -17,7 +16,6 @@ class Marlinkinfitprocessors(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl', 'tmadlener']
 
     version('master', branch='master')
-    k4_add_latest_commit_as_version(git)
     version('0.4.2',  sha256='539d0e703c2b4f1416fa29c0bcef6e98c197d5c939c3b11c1474eb965da462fe')
     version('0.4.1',  sha256='a6a1551239f909558d7cc31f9a06afb6a0c0124e0031d08bb2196097892bf19c')
     version('0.4',    sha256='dbae3a81a6afa435bb6962544ba67797e137c224c17c3c0f43d3e0f3bb034db6')

--- a/packages/marlinpandora/package.py
+++ b/packages/marlinpandora/package.py
@@ -3,8 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 
 class Marlinpandora(CMakePackage, Ilcsoftpackage):
@@ -18,7 +17,6 @@ class Marlinpandora(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
-    k4_add_latest_commit_as_version(git)
     version('3.0.1', sha256='2caecf5aa804dc0a0e2e4d6e87ad9100f76eafd1fd258f73130a9b476f9a4378')
 
 

--- a/packages/marlinreco/package.py
+++ b/packages/marlinreco/package.py
@@ -3,8 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 
 class Marlinreco(CMakePackage, Ilcsoftpackage):
@@ -17,7 +16,6 @@ class Marlinreco(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
-    k4_add_latest_commit_as_version(git)
     version('1.32', sha256='0ea3bee03e2bec1924b5876675043b592a942bc8cf306eb7056eaf03ac1748f6')
     version('1.31', sha256='eeb823f2476e1d31a54997b1a09fcc20cc8f3555a9f677054eacd5f44d4f59ee')
     version('1.30', sha256='e3b22a3f974232e4cc785326ad0dfd283b377cffda3245166f419b170276b6ff')

--- a/packages/marlintrk/package.py
+++ b/packages/marlintrk/package.py
@@ -4,8 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 
 class Marlintrk(CMakePackage, Ilcsoftpackage):
@@ -19,7 +18,6 @@ class Marlintrk(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
-    k4_add_latest_commit_as_version(git)
     version('2.9',     sha256='a1ccec25aea02d62f22d98cffc870ac199e455aa31100b6fa8795a8dc34cdcc0')
     version('2.8',     sha256='bd3b0074c06e2b778c74d1aeb2c989c39100a8adf5018792db599f84cb946c14')
     version('2.7',     sha256='c6e556d18ae6f2f3ae6c0fd8aa4322ce866e08b54b48ce95d09636443eff53ea')

--- a/packages/marlintrkprocessors/package.py
+++ b/packages/marlintrkprocessors/package.py
@@ -4,8 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 
 class Marlintrkprocessors(CMakePackage, Ilcsoftpackage):
@@ -18,7 +17,6 @@ class Marlintrkprocessors(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
-    k4_add_latest_commit_as_version(git)
     version('2.12', sha256='ac1a3af380c837868649c8b7767e7641d25a1ecf40690726d55a9bcc58a54640')
     version('2.11', sha256='49a567831e2b7a0c43ded955ce31fbe7d467a59960f4bcc2c2120e20762639b0')
 

--- a/packages/marlinutil/package.py
+++ b/packages/marlinutil/package.py
@@ -4,8 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 
 class Marlinutil(CMakePackage, Ilcsoftpackage):
@@ -20,7 +19,6 @@ class Marlinutil(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
-    k4_add_latest_commit_as_version(git)
     version('1.16.1', sha256='f8e03cba4144b9797fa01321aeb1c2f01967d1fcb10089e7b1765c32e4346508')
     version('1.16', sha256='7f80a726e3b08653a88487b87618fca277d59fe22a448ce15043f8495f1108e9')
     version('1.15.1',  sha256='05e878c9aae4a675e37ad2c63abc0b1c4c2a45dcb2e3c9ae5c31e7e6f64118bf')

--- a/packages/overlay/package.py
+++ b/packages/overlay/package.py
@@ -3,8 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 
 class Overlay(CMakePackage, Ilcsoftpackage):
@@ -17,7 +16,6 @@ class Overlay(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
-    k4_add_latest_commit_as_version(git)
     version('0.22.3', sha256='4a26b407a9275735c6ae156fdf073cbc6ea820e474d8e5ccc051753429a01ae1')
     version('0.22.2', sha256='305bdf568dc5fd221d6bd5d499cc25f7c567cc3ae21ff2954409a66549e4150f')
     version('0.22.1',   sha256='2f3ca472fe6aae44cdae0553f0e65b3c086a0d887d9cf53fd19468fb6107155b')

--- a/packages/pandoraanalysis/package.py
+++ b/packages/pandoraanalysis/package.py
@@ -3,8 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 
 class Pandoraanalysis(CMakePackage, Ilcsoftpackage):
@@ -19,7 +18,6 @@ class Pandoraanalysis(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
-    k4_add_latest_commit_as_version(git)
     version('2.0.1', sha256='cab082096921d60390054bb0da6afc5eaee4df28411266d4404f9b3f50048e39')
 
 

--- a/packages/pandorapfa/package.py
+++ b/packages/pandorapfa/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack import *
 
 
 class Pandorapfa(Package):

--- a/packages/pandorasdk/package.py
+++ b/packages/pandorasdk/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack import *
 
 
 class Pandorasdk(CMakePackage):

--- a/packages/physsim/package.py
+++ b/packages/physsim/package.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage 
 class Physsim(CMakePackage, Ilcsoftpackage):
     """Physsim is a matrix element package."""

--- a/packages/py-pyg4ometry/package.py
+++ b/packages/py-pyg4ometry/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack import *
 
 
 class PyPyg4ometry(PythonPackage):

--- a/packages/raida/package.py
+++ b/packages/raida/package.py
@@ -3,8 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage, k4_add_latest_commit_as_version
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 
 class Raida(CMakePackage, Ilcsoftpackage):
@@ -17,7 +16,6 @@ class Raida(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
-    k4_add_latest_commit_as_version(git)
     version('1.9.0', sha256='53ad3fd7c62e5eba70e6d6099e5ef4d92920399afb7b31dc8008b6ad865a9e85')
 
 

--- a/packages/tricktrack/package.py
+++ b/packages/tricktrack/package.py
@@ -1,5 +1,3 @@
-from spack import *
-from spack.pkg.k4.key4hep_stack import k4_add_latest_commit_as_version
 
 
 class Tricktrack(CMakePackage):
@@ -13,7 +11,6 @@ class Tricktrack(CMakePackage):
     tags = ['hep']
 
     version('master', branch='master')
-    k4_add_latest_commit_as_version(git)
     version('1.0.9', sha256='988cedbb28ec8f5cc95b762aa8a38e36d75cfc47bd009c9dc4ef365e9751b80d')
     version('1.0.8', sha256='fe5f8d178f8a0a28ac423ad6e9c449772ba547ec3ef7e365c4644d9b5b44cf85')
     version('1.0.7', sha256='e567de7c3c6e8096bd77873ac59fc4667661cdb380d089dcd6443a9d9834f3ef')


### PR DESCRIPTION
Cleanup of the macros that are superseded by scripts/fetch_nightly_versions.py

BEGINRELEASENOTES
- Remove deprecated k4_add_latest commit macros

ENDRELEASENOTES
