### PR TITLE
larcontent: turn off warning for clang

### DIFF
--- a/packages/larcontent/package.py
+++ b/packages/larcontent/package.py
@@ -39,7 +39,7 @@ class Larcontent(CMakePackage):
     def cmake_args(self):
         args = [
                 '-DCMAKE_MODULE_PATH=%s' % self.spec["pandorapfa"].prefix.cmakemodules,
-                "-DCMAKE_CXX_FLAGS=-std=c++17 -Wno-unused-private-field"]
+                "-DCMAKE_CXX_FLAGS=-std=c++17 -Wno-unused-private-field -Wno-unused-but-set-variable"]
         return args
 
     def url_for_version(self, version):


### PR DESCRIPTION
BEGINRELEASENOTES
- add Wno-unused-but-set-variable for clang build
ENDRELEASENOTES
