### PR TITLE
remove USE_CXX11 option as it interferes with newer C++ versions

### DIFF
--- a/packages/ilcutil/package.py
+++ b/packages/ilcutil/package.py
@@ -21,6 +21,8 @@ class Ilcutil(CMakePackage, Ilcsoftpackage):
     version('1.6', sha256='09083890721704f39a3e902dc660db5326027cc38446b813233d04ec3233ba2e')
 
     patch("installdoc.patch", when="@:1.6.1")
+    # Remove use_cxx11 patch since this conflicts with cxxstd
+    patch("remove-set-cxx-standard.patch")
 
     variant('cxxstd',
             default='17',

--- a/packages/ilcutil/remove-set-cxx-standard.patch
+++ b/packages/ilcutil/remove-set-cxx-standard.patch
@@ -1,0 +1,23 @@
+diff --git a/cmakemodules/ilcsoft_default_cxx_flags.cmake b/cmakemodules/ilcsoft_default_cxx_flags.cmake
+index 9660784..4002353 100644
+--- a/cmakemodules/ilcsoft_default_cxx_flags.cmake
++++ b/cmakemodules/ilcsoft_default_cxx_flags.cmake
+@@ -31,18 +31,6 @@ FOREACH( FLAG ${COMPILER_FLAGS} )
+ ENDFOREACH()
+ 
+ OPTION( USE_CXX11 "Use CXX Standard 2011" True )
+-IF( USE_CXX11 )
+-  SET( FLAG "-std=c++11" )
+-  SET( FLAG_WORD "stdCXX11" )
+-  CHECK_CXX_COMPILER_FLAG( ${FLAG} CXX_FLAG_WORKS_${FLAG_WORD} )
+-  IF( ${CXX_FLAG_WORKS_${FLAG_WORD}} )
+-    SET( CMAKE_CXX_FLAGS "${FLAG} ${CMAKE_CXX_FLAGS}")
+-  ELSE()
+-    MESSAGE( FATAL_ERROR "Cannot add ${FLAG} to CMAKE_CXX_FLAGS, but c++11 was requested, check your compiler" )
+-  ENDIF()
+-ELSE()
+-  MESSAGE( STATUS "NOT building with CXX11 standard" )
+-ENDIF()
+ 
+ IF( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.9 )
+   SET( CMAKE_CXX_FLAGS "-fdiagnostics-color=auto ${CMAKE_CXX_FLAGS}" )


### PR DESCRIPTION
BEGINRELEASENOTES
- patch ilcutil so that dependents that use new c++ compilers do not fail
ENDRELEASENOTES
