### PR TITLE
Add utility to automatically generate g4data externals config

### DIFF
--- a/spack-utilities/utilities/cmd/g4data.py
+++ b/spack-utilities/utilities/cmd/g4data.py
@@ -2,7 +2,7 @@
 
 import argparse
 import sys
-import yaml
+import ruamel.yaml as yaml
 
 import spack
 import spack.cmd

--- a/spack-utilities/utilities/cmd/g4data.py
+++ b/spack-utilities/utilities/cmd/g4data.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+import argparse
+import sys
+import yaml
+
+import spack
+import spack.cmd
+import spack.store
+from spack.database import InstallStatuses
+
+description = ('Find all installed geant4-data packages and dump them into a '
+               'package.yaml compatible format marking all geant4-data packages'
+               ' as non-buildable external packages')
+section = 'utilities'
+level = 'short'
+
+def setup_parser(subparser):
+    subparser.add_argument('-o', '--output', default=sys.stdout,
+                           type=argparse.FileType('w'),
+                           help='where to dump the output')
+    subparser.add_argument('--only-data', action='store_true', default=False,
+                           help='Do not include the geant4-data bundle packages in the output')
+
+
+def g4data(parser, args):
+    query_args = {
+        'installed': [InstallStatuses.INSTALLED],
+        'explicit': False,
+    }
+
+    # Get all geant4-data packages
+    g4data_specs = {}
+    for s in spack.store.db.query('geant4-data', **query_args):
+        # Only include the top-level bundle packages if desired
+        if not args.only_data:
+            g4data_specs[s.dag_hash()] = s
+        for _, ds in s.traverse(root=False, depth=True):
+            g4data_specs[ds.dag_hash()] = ds
+
+    # Put everything into a dictionary that can be put into a packages.yaml file
+    # when dumped
+    packages = {}
+    for _, spec in g4data_specs.items():
+        spec_path = {
+            'spec': spec.format('{name}@{version}'),
+            'prefix': spec.format('{prefix}')
+        }
+
+        if spec.name not in packages:
+            packages[spec.name] = {'externals': [], 'buildable': False}
+
+        packages[spec.name]['externals'].append(spec_path)
+
+    yaml.dump({'packages': packages}, args.output)


### PR DESCRIPTION
BEGINRELEASENOTES
- Add a spack extension command `g4data` that automatically collects the geant4-data packages that are installed and dumps them into a `package.yaml` compatible format marking all of them as non-buildable.

ENDRELEASENOTES

This is a spack [extension](https://spack.readthedocs.io/en/latest/extensions.html), so it is necessary to add it to `config.yaml` via
```yaml
config:
  extensions:
    - <path-to>/key4hep-spack/spack-utilities
```
With that in place it is possible to just do
```sh
spack g4data
```
to collect all installed geant4-data packages and mark them as non-buildable. Obviously, you will have to put the output to a suitable `packages.yaml` (or similar) file in order to make spack aware of this.