### PR TITLE
Enable build testing in nightlies

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -75,10 +75,11 @@ build-spack-nightlies:
         # avoid bootstrapping clingo
         - source setup_clingo_centos7.sh
         - spack env activate .
+        - spack repo add ../..
         - spack add key4hep-stack@${KEY4HEP_RELEASE_VERSION}
-        - spack concretize -f 
+        - spack concretize -f --test=root --reuse
         # compile onwards and upwards
-        - spack install --test=root
+        - spack install --test=root --reuse
 
 
 
@@ -132,6 +133,7 @@ build-spack-release:
         # activate environment
         - cd environments/${SPACKENV}
         - spack env activate .
+        - spack repo add ../..
         # config debug printouts
         - spack config blame config # debug printout
         - spack config blame packages # debug printout

--- a/environments/key4hep-common/packages.yaml
+++ b/environments/key4hep-common/packages.yaml
@@ -133,8 +133,6 @@ packages:
     target: []
     providers: {}
     compiler: []
-  acts:
-    version: [5.00.0]
   binutils:
     variants: +plugins       
   dd4hep:

--- a/packages/cepcsw/package.py
+++ b/packages/cepcsw/package.py
@@ -29,7 +29,7 @@ class Cepcsw(CMakePackage, Key4hepPackage):
           sha256='87bf94536f5fd7fb675ca4eff25277331b7de94ef541f2bd8ea178a5e61fd20d', when="@0.2.1")
 
     depends_on('clhep')
-    depends_on('dd4hep +ddg4')
+    depends_on('dd4hep')
     depends_on('edm4hep')
     depends_on('k4fwcore@0.3.0:', when='@0.2:')
     depends_on('k4fwcore@0.2.0', when='@:0.1.99')

--- a/packages/clicperformance/package.py
+++ b/packages/clicperformance/package.py
@@ -51,7 +51,7 @@ class Clicperformance(CMakePackage, Ilcsoftpackage):
         spack_env.prepend_path('MARLIN_DLL', self.prefix.lib + "/libClicPerformance.so")
 
     def setup_build_environment(self, env):
-        k4_setup_env_for_framework_tests(env)
+        k4_setup_env_for_framework_tests(self.spec, env)
 
     def cmake_args(self):
         # C++ Standard

--- a/packages/clicperformance/package.py
+++ b/packages/clicperformance/package.py
@@ -52,6 +52,8 @@ class Clicperformance(CMakePackage, Ilcsoftpackage):
 
     def setup_build_environment(self, env):
         k4_setup_env_for_framework_tests(self.spec, env)
+        env.prepend_path('LD_LIBRARY_PATH', self.spec['dd4hep'].prefix.lib)
+        env.prepend_path('LD_LIBRARY_PATH', self.spec['dd4hep'].prefix.lib64)
 
     def cmake_args(self):
         # C++ Standard

--- a/packages/clicperformance/package.py
+++ b/packages/clicperformance/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
-
+from spack.pkg.k4.key4hep_stack import k4_setup_env_for_framework_tests
 
 class Clicperformance(CMakePackage, Ilcsoftpackage):
     """ Package containing processors and configurations to determine the performance of the CLIC detector model"""
@@ -14,6 +14,8 @@ class Clicperformance(CMakePackage, Ilcsoftpackage):
     git      = "https://github.com/iLCSoft/ClicPerformance.git"
 
     maintainers = ['vvolkl']
+
+    generator = "Ninja"
 
     version('master', branch='master')
     version('02-04-01', sha256='78fb40435eff722e81e29aaa7ad437cb17ee6f986d97242217a2fc66fbe1bf78')
@@ -27,15 +29,43 @@ class Clicperformance(CMakePackage, Ilcsoftpackage):
     depends_on('root')
     depends_on('dd4hep')
     depends_on('raida')
+    depends_on('lcgeo')
 
+    depends_on('ninja', type='build')
 
-    #TODO: build_testing
+    # for tests
+    # TODO: investigate why type='test' does not work
+    depends_on('marlindd4hep')
+    depends_on('kaltest')
+    depends_on('conformaltracking')
+    depends_on('overlay')
+    depends_on('marlinreco')
+    depends_on('marlintrkprocessors')
+    depends_on('ddmarlinpandora')
+    depends_on('fcalclusterer')
+    depends_on('lctuple')
+    depends_on('marlinfastjet')
+    depends_on('lcfiplus')
 
     def setup_run_environment(self, spack_env):
         spack_env.prepend_path('MARLIN_DLL', self.prefix.lib + "/libClicPerformance.so")
+
+    def setup_build_environment(self, env):
+        k4_setup_env_for_framework_tests(env)
 
     def cmake_args(self):
         # C++ Standard
         return [
             '-DCMAKE_CXX_STANDARD=%s' % self.spec['root'].variants['cxxstd'].value
         ]
+
+    # tests need installation, so skip here ...
+    def check(self):
+        pass
+
+    # ... and  add custom check step that runs after installation instead
+    @run_after('install')
+    def install_check(self):
+        with working_dir(self.build_directory):
+            if self.run_tests:
+                ninja('test')

--- a/packages/dual-readout/package.py
+++ b/packages/dual-readout/package.py
@@ -22,7 +22,6 @@ class DualReadout(CMakePackage, Key4hepPackage):
 
     depends_on('dd4hep')
     depends_on('hepmc3+rootio')
-    depends_on('fccsw')
     depends_on('fastjet')
     depends_on('root')
     depends_on('pythia8')

--- a/packages/dual-readout/package.py
+++ b/packages/dual-readout/package.py
@@ -20,7 +20,7 @@ class DualReadout(CMakePackage, Key4hepPackage):
     version('0.0.3', sha256='d35e7193c11385505494f11328d54a595b3ff953563bae06b8954c1ef24209b3')
     version('0.0.2', sha256='f76c1febf3d8e29d5287ba03eacbc244f8c615502295f7471579245376da91ad')
 
-    depends_on('dd4hep +ddg4')
+    depends_on('dd4hep')
     depends_on('hepmc3+rootio')
     depends_on('fccsw')
     depends_on('fastjet')

--- a/packages/fcalclusterer/package.py
+++ b/packages/fcalclusterer/package.py
@@ -60,4 +60,4 @@ class Fcalclusterer(CMakePackage, Ilcsoftpackage):
         spack_env.prepend_path('MARLIN_DLL', self.prefix.lib + "/libFCalClusterer.so")
 
     def setup_build_environment(self, env):
-        k4_setup_env_for_framework_tests(env)
+        k4_setup_env_for_framework_tests(self.spec, env)

--- a/packages/fcalclusterer/package.py
+++ b/packages/fcalclusterer/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
+from spack.pkg.k4.key4hep_stack import k4_setup_env_for_framework_tests
 
 
 class Fcalclusterer(CMakePackage, Ilcsoftpackage):
@@ -28,6 +29,11 @@ class Fcalclusterer(CMakePackage, Ilcsoftpackage):
     depends_on('root +unuran +math')
     depends_on('dd4hep')
 
+    # testing
+    depends_on('lcgeo')
+    depends_on('marlindd4hep')
+
+
     # CMAKE_INSTALL_PREFIX is overwritten by the package
     patch("install.patch", when="@:1.0.1")
     patch("random-shuffle-c17.patch", when="@:1.0.1")
@@ -42,8 +48,16 @@ class Fcalclusterer(CMakePackage, Ilcsoftpackage):
 
     @run_after('install')
     def install_source(self):
-        #make('install')
-        install_tree('.', self.prefix)
+        install_tree('.', self.prefix,
+                     ignore=lambda x: x in ('README.md',
+                                    'CMakeLists.xt',
+                                    'LICENSE',
+                                    '.clang-format',
+                                    'doc',
+                                    ))
 
     def setup_run_environment(self, spack_env):
         spack_env.prepend_path('MARLIN_DLL', self.prefix.lib + "/libFCalClusterer.so")
+
+    def setup_build_environment(self, env):
+        k4_setup_env_for_framework_tests(env)

--- a/packages/fcalclusterer/package.py
+++ b/packages/fcalclusterer/package.py
@@ -59,5 +59,14 @@ class Fcalclusterer(CMakePackage, Ilcsoftpackage):
     def setup_run_environment(self, spack_env):
         spack_env.prepend_path('MARLIN_DLL', self.prefix.lib + "/libFCalClusterer.so")
 
-    def setup_build_environment(self, env):
-        k4_setup_env_for_framework_tests(self.spec, env)
+    def setup_build_environment(self, spack_env):
+        k4_setup_env_for_framework_tests(self.spec, spack_env)
+        spack_env.prepend_path('MARLIN_DLL', self.spec['marlindd4hep'].prefix.lib + "/libMarlinDD4hep.so"    )   
+        spack_env.prepend_path('ROOT_INCLUDE_PATH', self.spec['dd4hep'].prefix.include) 
+        spack_env.prepend_path('LD_LIBRARY_PATH', self.spec['dd4hep'].prefix.lib)
+        # used p.ex. in ddsim to find DDDetectors dir
+        spack_env.set("DD4hepINSTALL", self.spec['dd4hep'].prefix)
+        spack_env.set("DD4HEP", self.spec['dd4hep'].prefix.examples)
+        spack_env.set("DD4hep_DIR", self.spec['dd4hep'].prefix)
+        spack_env.set("DD4hep_ROOT", self.spec['dd4hep'].prefix)
+ 

--- a/packages/fccanalyses/package.py
+++ b/packages/fccanalyses/package.py
@@ -16,6 +16,8 @@ class Fccanalyses(CMakePackage, Key4hepPackage):
     version('0.3.1', sha256='736e4243493d32744ef5b974ae4e60e43c1ab467ba58df6afdf495fccb165dc3')
     version('0.3.0', sha256='b9ad4f3d9a587f4a1666c9ff5880020f43564a4a0e615d2ce7169bc751134dcf')
     version('0.2.0', sha256='a4a9965751ae489495f8583129f4f0be4e55e8e676a66a08be35181f2395b955')
+
+    variant('dd4hep', default=True, description="Build DD4hep-dependent analyzers.")
     
     depends_on("root")
     depends_on("vdt")
@@ -24,8 +26,9 @@ class Fccanalyses(CMakePackage, Key4hepPackage):
     depends_on('edm4hep')
     depends_on('py-awkward')
     depends_on('fcc-edm', when="@:0.2.9")
-    depends_on('acts@5.00.0', when="@0.3.0:")
+    depends_on('acts', when="@0.3.0:")
     depends_on('eigen', when="@0.3.0:")
+    depends_on('dd4hep', when="@0.3.3: +dd4hep")
 
     # todo: update the cmake config to remove this
     def setup_build_environment(self, spack_env):

--- a/packages/fccsw/package.py
+++ b/packages/fccsw/package.py
@@ -47,4 +47,4 @@ class Fccsw(CMakePackage, Key4hepPackage):
 
     def setup_build_environment(self, env):
         self.setup_run_environment(env)
-        k4_setup_env_for_framework_tests(env)
+        k4_setup_env_for_framework_tests(self.spec, env)

--- a/packages/fccsw/package.py
+++ b/packages/fccsw/package.py
@@ -1,5 +1,7 @@
 
 from spack.pkg.k4.key4hep_stack import Key4hepPackage 
+from spack.pkg.k4.key4hep_stack import k4_setup_env_for_framework_tests
+
 
 class Fccsw(CMakePackage, Key4hepPackage):
     """Software framework of the FCC project"""
@@ -19,15 +21,15 @@ class Fccsw(CMakePackage, Key4hepPackage):
             multi=False,
             description='Use the specified C++ standard when building.')
 
-    depends_on("gaudi", type=("test", "run"))
-    depends_on("k4fwcore", type=("test", "run"))
-    depends_on("k4gen", type=("test", "run"))
-    depends_on("k4simdelphes", type=("test", "run"))
-    depends_on("fccdetectors", type=("test", "run"))
-    depends_on("k4simgeant4", type=("test", "run"))
-    depends_on("k4reccalorimeter", type=("test", "run"))
-    depends_on("lcgeo", type=("test", "run"))
-    depends_on("fccanalyses", type=("test", "run"))
+    depends_on("gaudi")
+    depends_on("k4fwcore")
+    depends_on("k4gen")
+    depends_on("k4simdelphes")
+    depends_on("fccdetectors")
+    depends_on("k4simgeant4")
+    depends_on("k4reccalorimeter")
+    depends_on("lcgeo")
+    depends_on("fccanalyses")
 
     def cmake_args(self):
         args = []
@@ -43,6 +45,6 @@ class Fccsw(CMakePackage, Key4hepPackage):
         spack_env.set("FCCSW", self.prefix.share.FCCSW)
         spack_env.prepend_path("PYTHONPATH", self.prefix.python)
 
-    def setup_build_environment(self, spack_env):
-        spack_env.set("FCCSW", self.prefix.share.FCCSW)
-        spack_env.prepend_path("PYTHONPATH", self.prefix.python)
+    def setup_build_environment(self, env):
+        self.setup_run_environment(env)
+        k4_setup_env_for_framework_tests(env)

--- a/packages/k4clue/package.py
+++ b/packages/k4clue/package.py
@@ -5,6 +5,7 @@
 
 
 from spack.pkg.k4.key4hep_stack import Key4hepPackage
+from spack.pkg.k4.key4hep_stack import k4_setup_env_for_framework_tests
 
 
 class K4clue(CMakePackage, Key4hepPackage):
@@ -32,4 +33,8 @@ class K4clue(CMakePackage, Key4hepPackage):
     def setup_run_environment(self, spack_env):
         spack_env.set("K4CLUE", self.prefix.share.k4Clue)
         spack_env.prepend_path("PYTHONPATH", self.prefix.python)
+
+    
+    def setup_build_environment(self, env):
+        k4_setup_env_for_framework_tests(self.spec, env)
 

--- a/packages/k4fwcore/package.py
+++ b/packages/k4fwcore/package.py
@@ -54,4 +54,4 @@ class K4fwcore(CMakePackage, Ilcsoftpackage):
         spack_env.prepend_path("PATH", self.prefix.scripts)
 	
     def setup_build_environment(self, env):
-        k4_setup_env_for_framework_tests(env)
+        k4_setup_env_for_framework_tests(self.spec, env)

--- a/packages/k4fwcore/package.py
+++ b/packages/k4fwcore/package.py
@@ -54,4 +54,6 @@ class K4fwcore(CMakePackage, Ilcsoftpackage):
         spack_env.prepend_path("PATH", self.prefix.scripts)
 	
     def setup_build_environment(self, env):
+        env.prepend_path('LD_LIBRARY_PATH', self.spec['gaudi'].prefix.lib)
+        env.prepend_path('LD_LIBRARY_PATH', self.spec['gaudi'].prefix.lib64)
         k4_setup_env_for_framework_tests(self.spec, env)

--- a/packages/k4fwcore/package.py
+++ b/packages/k4fwcore/package.py
@@ -1,4 +1,5 @@
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
+from spack.pkg.k4.key4hep_stack import k4_setup_env_for_framework_tests
 
 
 class K4fwcore(CMakePackage, Ilcsoftpackage):
@@ -52,3 +53,5 @@ class K4fwcore(CMakePackage, Ilcsoftpackage):
         spack_env.prepend_path('PYTHONPATH', self.prefix.python)
         spack_env.prepend_path("PATH", self.prefix.scripts)
 	
+    def setup_build_environment(self, env):
+        k4_setup_env_for_framework_tests(env)

--- a/packages/k4gen/package.py
+++ b/packages/k4gen/package.py
@@ -1,5 +1,5 @@
-
-from spack.pkg.k4.key4hep_stack import Key4hepPackage 
+from spack.pkg.k4.key4hep_stack import Key4hepPackage
+from spack.pkg.k4.key4hep_stack import k4_setup_env_for_framework_tests 
 
 class K4gen(CMakePackage, Key4hepPackage):
     """Generator components for the Key4hep framework"""
@@ -50,3 +50,20 @@ class K4gen(CMakePackage, Key4hepPackage):
         spack_env.prepend_path('PYTHONPATH', self.prefix.python)
         spack_env.prepend_path("PATH", self.prefix.scripts)
         spack_env.set("K4GEN", self.prefix.share.k4Gen)
+
+
+    def setup_build_environment(self, env):
+        k4_setup_env_for_framework_tests(self.spec, env)
+        env.set("K4GEN", self.prefix.share.k4Gen)
+    
+    def check(self):
+        pass
+    
+  
+    # ... and  add custom check step that runs after installation instead
+    @run_after('install')
+    def install_check(self):
+        with working_dir(self.build_directory):
+            if self.run_tests:
+                ninja('test')
+        

--- a/packages/k4lcioreader/package.py
+++ b/packages/k4lcioreader/package.py
@@ -17,6 +17,10 @@ class K4lcioreader(CMakePackage, Key4hepPackage):
     version('0.2.0', sha256='346fc2ba4b4175895597e093f566ba6407be9eeb9cde0766304e0f19ad03e081')
     version('0.1.0', sha256='996d1ff78c0a8a2f7f358dd4ea19f955853ad0902ee86b99c484de58c5fc2e2c')
 
+    patch('https://github.com/key4hep/k4LCIOReader/commit/81f4f47ecc7ce904189986e08b949d477c0e4f08.patch',
+          sha256='5c88414128ccc9af6b53669f79ac5e4a61c4841d7de5b00a56400c9e92b7d37d',
+          when='@0.4.0:')
+
     variant('cxxstd',
             default='17',
             values=('14', '17', '20'),

--- a/packages/k4lcioreader/package.py
+++ b/packages/k4lcioreader/package.py
@@ -1,4 +1,3 @@
-
 from spack.pkg.k4.key4hep_stack import Key4hepPackage
 
 class K4lcioreader(CMakePackage, Key4hepPackage):
@@ -19,7 +18,7 @@ class K4lcioreader(CMakePackage, Key4hepPackage):
 
     patch('https://github.com/key4hep/k4LCIOReader/commit/81f4f47ecc7ce904189986e08b949d477c0e4f08.patch',
           sha256='5c88414128ccc9af6b53669f79ac5e4a61c4841d7de5b00a56400c9e92b7d37d',
-          when='@0.4.0:')
+          when='@0.4.0')
 
     variant('cxxstd',
             default='17',

--- a/packages/k4pandora/package.py
+++ b/packages/k4pandora/package.py
@@ -26,7 +26,7 @@ class K4pandora(CMakePackage, Key4hepPackage):
     version('master', branch='master')
 
     depends_on('clhep')
-    depends_on('dd4hep +ddg4')
+    depends_on('dd4hep')
     depends_on('edm4hep')
     depends_on('k4fwcore@0.3.0:')
     depends_on('gaudi@35.0:')

--- a/packages/k4projecttemplate/package.py
+++ b/packages/k4projecttemplate/package.py
@@ -1,5 +1,5 @@
-
 from spack.pkg.k4.key4hep_stack import Key4hepPackage
+from spack.pkg.k4.key4hep_stack import k4_setup_env_for_framework_tests
 
 class K4projecttemplate(CMakePackage, Key4hepPackage):
     """Template for Key4hep framework projects"""
@@ -38,3 +38,7 @@ class K4projecttemplate(CMakePackage, Key4hepPackage):
     def setup_run_environment(self, spack_env):
         spack_env.prepend_path('PYTHONPATH', self.prefix.python)
         spack_env.set("K4PROJECTTEMPLATE", self.prefix.share.k4ProjectTemplate)
+    
+
+    def setup_build_environment(self, env):
+        k4_setup_env_for_framework_tests(self.spec, env)

--- a/packages/k4reccalorimeter/package.py
+++ b/packages/k4reccalorimeter/package.py
@@ -29,7 +29,7 @@ class K4reccalorimeter(CMakePackage, Key4hepPackage):
     depends_on("edm4hep")
     depends_on("podio")
     depends_on('k4fwcore@1:')
-    depends_on("dd4hep +ddg4")
+    depends_on("dd4hep")
     depends_on("fccdetectors")
     depends_on('k4gen')
     depends_on('k4simgeant4')

--- a/packages/k4reccalorimeter/package.py
+++ b/packages/k4reccalorimeter/package.py
@@ -1,4 +1,3 @@
-
 from spack.pkg.k4.key4hep_stack import Key4hepPackage 
 from spack.pkg.k4.key4hep_stack import k4_setup_env_for_framework_tests
 
@@ -41,6 +40,8 @@ class K4reccalorimeter(CMakePackage, Key4hepPackage):
         return args
 
     def setup_run_environment(self, spack_env):
+        spack_env.prepend_path('LD_LIBRARY_PATH', self.prefix.lib)
+        spack_env.prepend_path('LD_LIBRARY_PATH', self.prefix.lib64)
         spack_env.prepend_path('PYTHONPATH', self.prefix.python)
         spack_env.prepend_path("PATH", self.prefix.scripts)
         spack_env.set("K4RECCALORIMETER", self.prefix.share.k4RecCalorimeter)

--- a/packages/k4reccalorimeter/package.py
+++ b/packages/k4reccalorimeter/package.py
@@ -47,7 +47,7 @@ class K4reccalorimeter(CMakePackage, Key4hepPackage):
 
     def setup_build_environment(self, env):
         self.setup_run_environment(env)
-        k4_setup_env_for_framework_tests(env)
+        k4_setup_env_for_framework_tests(self.spec, env)
 
     def check(self):
         pass

--- a/packages/k4simdelphes/package.py
+++ b/packages/k4simdelphes/package.py
@@ -59,4 +59,4 @@ class K4simdelphes(CMakePackage, Ilcsoftpackage):
         env.prepend_path("PYTHONPATH", self.prefix.python)
 
     def setup_build_environment(self, env):
-        k4_setup_env_for_framework_tests(env)
+        k4_setup_env_for_framework_tests(self.spec, env)

--- a/packages/k4simdelphes/package.py
+++ b/packages/k4simdelphes/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
+from spack.pkg.k4.key4hep_stack import k4_setup_env_for_framework_tests
 
 class K4simdelphes(CMakePackage, Ilcsoftpackage):
     """EDM4HEP output for Delphes."""
@@ -30,15 +31,17 @@ class K4simdelphes(CMakePackage, Ilcsoftpackage):
     variant('delphes_hepmc', default=True, description='Build standalone executable with Hepmc input.')
     variant('delphes_pythia_evtgen', default=True, description='Build standalone executable with Pythia+EvtGen input')
 
-    depends_on('edm4hep')
-    depends_on('delphes@3.4.3pre10:')
+    depends_on('edm4hep', type=('build', 'link', 'run'))
+    depends_on('podio', type=('build', 'link', 'run'))
+    depends_on('delphes@3.4.3pre10:', type=('build', 'link', 'run'))
     depends_on('pythia8', when="+delphes_pythia")
     depends_on('evtgen+pythia8', when="+delphes_pythia_evtgen")
     depends_on('hepmc', when="+delphes_hepmc")
+    depends_on('hepmc3', when="+framework")
     depends_on('k4fwcore', when="+framework")
 
-    depends_on('catch2@3.0.1:', type=('test'))
-    depends_on('k4gen', when="+integration_tests", type=('test'))
+    depends_on('catch2@3.0.1:', type=('build', 'test'))
+    depends_on('k4gen', when="+integration_tests", type=('build', 'test', 'run'))
 
     def cmake_args(self):
         args = [
@@ -51,17 +54,9 @@ class K4simdelphes(CMakePackage, Ilcsoftpackage):
         ]
         return args
 
-    def setup_build_environment(self, env):
-        env.set('PYTHIA8', self.spec["pythia8"].prefix)
-        env.prepend_path("LD_LIBRARY_PATH", self.prefix.lib)
-        env.prepend_path("LD_LIBRARY_PATH", self.prefix.lib64)
-
     def setup_run_environment(self, env):
         env.set("K4SIMDELPHES", self.prefix.share.k4SimDelphes)
         env.prepend_path("PYTHONPATH", self.prefix.python)
 
-    def setup_dependent_build_environment(self, spack_env, dependent_spec):
-        spack_env.set("K4SIMDELPHES", self.prefix.share.k4SimDelphes)
-        spack_env.prepend_path('PYTHONPATH', self.prefix.python)
-        spack_env.prepend_path("LD_LIBRARY_PATH", self.prefix.lib)
-        spack_env.prepend_path("LD_LIBRARY_PATH", self.prefix.lib64)
+    def setup_build_environment(self, env):
+        k4_setup_env_for_framework_tests(env)

--- a/packages/k4simgeant4/package.py
+++ b/packages/k4simgeant4/package.py
@@ -19,7 +19,7 @@ class K4simgeant4(CMakePackage, Key4hepPackage):
             description='Use the specified C++ standard when building.')
 
     depends_on('clhep')
-    depends_on('dd4hep +ddg4')
+    depends_on('dd4hep')
     depends_on('k4fwcore@1.0:')
     depends_on('geant4')
     depends_on('edm4hep')

--- a/packages/key4hep-stack/common.py
+++ b/packages/key4hep-stack/common.py
@@ -4,6 +4,7 @@ Common methods for use in Key4hep recipes
 
 from spack import *
 from spack.directives import *
+from spack.user_environment import *
 
 import os
 import platform
@@ -21,7 +22,16 @@ import spack.store
 from spack.package import PackageBase
 
 
-
+def k4_setup_env_for_framework_tests(env):
+    """Setup for tests that need the run environment.
+    """
+    runenv = environment_modifications_for_spec(self.spec)
+    env.extend(runenv)
+    for dspec in self.spec.traverse(root=False, order='post'):
+      dspec.package.setup_run_environment(env)
+      # make sure that ROOT_INCLUDE_PATH is set
+      if (dspec.satisfies('^root')):
+        self.spec['root'].package.setup_dependent_run_environment(env, dspec)
 
 
 def k4_generate_setup_script(env_mod, shell='sh'):

--- a/packages/key4hep-stack/common.py
+++ b/packages/key4hep-stack/common.py
@@ -22,16 +22,16 @@ import spack.store
 from spack.package import PackageBase
 
 
-def k4_setup_env_for_framework_tests(env):
+def k4_setup_env_for_framework_tests(spec, env):
     """Setup for tests that need the run environment.
     """
-    runenv = environment_modifications_for_spec(self.spec)
+    runenv = environment_modifications_for_spec(spec)
     env.extend(runenv)
-    for dspec in self.spec.traverse(root=False, order='post'):
+    for dspec in spec.traverse(root=False, order='post'):
       dspec.package.setup_run_environment(env)
       # make sure that ROOT_INCLUDE_PATH is set
       if (dspec.satisfies('^root')):
-        self.spec['root'].package.setup_dependent_run_environment(env, dspec)
+        spec['root'].package.setup_dependent_run_environment(env, dspec)
 
 
 def k4_generate_setup_script(env_mod, shell='sh'):

--- a/packages/kkmcee/package.py
+++ b/packages/kkmcee/package.py
@@ -31,7 +31,7 @@ class Kkmcee(AutotoolsPackage):
     patch('gcc4a.patch', when="@4.32.01:")
     patch('gcc6.patch')
     patch('gcc5.patch')
-    patch('clang01.patch', when="@4.32.1:")
+    #patch('clang01.patch', when="@4.32.1:")
     patch('KKMCee-dev-4.30.patch', level=0, when='@:4.30')
     patch('KKMCee-dev-4.32.01.patch', level=0, when='@4.31:4.32.01')
 

--- a/packages/lcgeo/package.py
+++ b/packages/lcgeo/package.py
@@ -36,8 +36,7 @@ class Lcgeo(CMakePackage, Ilcsoftpackage):
     depends_on('python', type='build')
     depends_on('ninja', type='build')
 
-    #patch('xmlcomment2.patch')
-    patch(url='https://github.com/iLCSoft/lcgeo/commit/cb87609446255c3a94da867ad7801a62ff3b6b05.patch',
+    patch('https://github.com/iLCSoft/lcgeo/commit/cb87609446255c3a94da867ad7801a62ff3b6b05.patch',
           sha256='3e02ca5c89558342d8fd2489463c285af5a5500baeba2faf8d41f8ec3ae2f487',
           when='@0.16.7')
 

--- a/packages/lcgeo/package.py
+++ b/packages/lcgeo/package.py
@@ -11,12 +11,14 @@ class Lcgeo(CMakePackage, Ilcsoftpackage):
 
     homepage = "https://github.com/iLCSoft/lcgeo"
     git      = "https://github.com/iLCSoft/lcgeo.git"
-    url      = "https://github.com/iLCSoft/lcgeo/archive/v00-16-06.tar.gz"
+    url      = "https://github.com/iLCSoft/lcgeo/archive/v00-16-07.tar.gz"
+
+    generator = 'Ninja'
 
     maintainers = ['vvolkl']
 
     version('master', branch='master')
-    version('0.16.7', sha256='bde23af3c8dc695c4dcbb7460764c23e75dc534cd8a6170190e50a1a8083d45c')
+    version('0.16.7', tag='v00-16-07')
     version('0.16.6', sha256='0eef7137ad69b771e5cf8a3f4a71e060e9d57ee825d8d944fa6a0dec8c2dad60')
     version('0.16.5', sha256='a46738b2479c0469b06584f82801bf2dd546623180300753de0b5684abd12a05')
 
@@ -28,8 +30,16 @@ class Lcgeo(CMakePackage, Ilcsoftpackage):
 
     depends_on('lcio')
     depends_on('dd4hep')
+    depends_on('lcio')
     depends_on('boost')
     depends_on('root')
+    depends_on('python', type='build')
+    depends_on('ninja', type='build')
+
+    #patch('xmlcomment2.patch')
+    patch(url='https://github.com/iLCSoft/lcgeo/commit/cb87609446255c3a94da867ad7801a62ff3b6b05.patch',
+          sha256='3e02ca5c89558342d8fd2489463c285af5a5500baeba2faf8d41f8ec3ae2f487',
+          when='@0.16.7')
 
 
     def cmake_args(self):
@@ -53,6 +63,13 @@ class Lcgeo(CMakePackage, Ilcsoftpackage):
         env.set('LCGEO', self.prefix.share.lcgeo.compact)
         env.set('lcgeo_DIR', self.prefix.share.lcgeo.compact)
 
+    def setup_build_environment(self, env):
+        env.set('LCGEO', self.prefix.share.lcgeo.compact)
+        env.set('lcgeo_DIR', self.prefix.share.lcgeo.compact)
+        env.prepend_path("LD_LIBRARY_PATH", self.spec['lcio'].prefix + '/lib')
+        env.prepend_path("LD_LIBRARY_PATH", self.spec['lcio'].prefix + '/lib64')
+        env.prepend_path("LD_LIBRARY_PATH", self.prefix.lib)
+
     def setup_dependent_build_environment(self, spack_env, dependent_spec):
         spack_env.set('LCGEO', self.prefix.share.lcgeo.compact)
         spack_env.set('lcgeo_DIR', self.prefix.share.lcgeo.compact)
@@ -60,3 +77,17 @@ class Lcgeo(CMakePackage, Ilcsoftpackage):
         spack_env.prepend_path("LD_LIBRARY_PATH", self.spec['lcgeo'].prefix.lib64)
         spack_env.prepend_path("LD_LIBRARY_PATH", self.spec['lcio'].prefix + '/lib')
         spack_env.prepend_path("LD_LIBRARY_PATH", self.spec['lcio'].prefix + '/lib64')
+
+    # dd4hep tests need to run after install step:
+    # disable the usual check
+    def check(self):
+        pass
+
+    # instead add custom check step that runs after installation
+    @run_after('install')
+    def install_check(self):
+        print(self)
+        with working_dir(self.build_directory):
+            if self.run_tests:
+                ninja('test')
+

--- a/scripts/ci_setup_spack.sh
+++ b/scripts/ci_setup_spack.sh
@@ -1,4 +1,3 @@
 # set up spack inside the k4-spack repo
  if [ -n "$SPACK_VERSION" ]; then git clone  https://github.com/key4hep/spack ; cd spack; git checkout $SPACK_VERSION; cd ..; else git clone --depth 1 https://github.com/key4hep/spack; fi 
  source spack/share/spack/setup-env.sh
-spack repo add . || true

--- a/scripts/fetch_nightly_versions.py
+++ b/scripts/fetch_nightly_versions.py
@@ -77,8 +77,9 @@ if __name__ == "__main__":
     k4_add_latest_commit_as_dependency("k4simdelphes", "key4hep/k4SimDelphes", when="@master",
 				 giturl="https://api.github.com/repos/%s/commits/main")
 
-    k4_add_latest_commit_as_dependency("k4clue", "key4hep/k4clue", when="@master",
-				 giturl="https://api.github.com/repos/%s/commits/main")
+    # needs to fix tests
+    #k4_add_latest_commit_as_dependency("k4clue", "key4hep/k4clue", when="@master",
+		#		 giturl="https://api.github.com/repos/%s/commits/main")
 
     k4_add_latest_commit_as_dependency("k4gen", "hep-fcc/k4Gen", when="@master",
 				 giturl="https://api.github.com/repos/%s/commits/main")


### PR DESCRIPTION
This will run `make test` on the packages in `spack.yaml`, which are just the ones that are built from  master:  https://github.com/key4hep/key4hep-spack/blob/release/scripts/fetch_nightly_versions.py

Some packages require the tests to be run after the packages are installed, and most of them require them to be run  in the `run` environment, so a helper function is added to add the run environment to the build environment (in which the tests are run in spack)