### PR TITLE
Make fcc-edm use the CMakePackage default release types

### DIFF
--- a/packages/fcc-edm/package.py
+++ b/packages/fcc-edm/package.py
@@ -24,11 +24,6 @@ class FccEdm(CMakePackage, Key4hepPackage):
     version('0.2.1', 'c68d0ab3c07d7f5c885b6d2be7a3be74')
     version('0.2', 'fe014e238e8afc76523f2e1ada9bc087')
 
-    variant('build_type', default='Release',
-            description='The build type to build',
-            values=('Debug', 'Release'))
-
-
     patch('cpack.patch', when="@:0.5.6")
 
     depends_on('cmake', type='build')


### PR DESCRIPTION
BEGINRELEASENOTES
- Make fcc-edm use the CMakePackage default release types instead of providing their own variant

ENDRELEASENOTES

Couldn't find this in #334 so made it a separate PR. Makes it easier to concretize in an environment with `build_type=RelWithDebInfo`.