### PR TITLE
Remove emacs from key4hep-stack

### DIFF
--- a/packages/key4hep-stack/package.py
+++ b/packages/key4hep-stack/package.py
@@ -99,7 +99,6 @@ class Key4hepStack(BundlePackage, Key4hepPackage):
     depends_on('cmake', when='+devtools')
     depends_on('man-db', when='+devtools')
     depends_on('gdb', when='+devtools')
-    depends_on('emacs+X toolkit=athena', when='+devtools')
     depends_on('ninja', when='+devtools')
     depends_on('py-ipython', when='+devtools')
     depends_on('doxygen', when='+devtools')


### PR DESCRIPTION
Using the system emacs from lxplus should no longer be an issue ( as spack now does not use the LD_LIBRARY_PATH as extensively). Since a user complained about the installed `ctags` executable interfering with other packages it seems bettter to remove it altogether.

