### PR TITLE
Change k4actstracking package to run a cmake build

### DIFF
--- a/packages/k4actstracking/package.py
+++ b/packages/k4actstracking/package.py
@@ -1,7 +1,7 @@
 
 from spack.pkg.k4.key4hep_stack import Key4hepPackage
 
-class K4actstracking(BundlePackage, Key4hepPackage):
+class K4actstracking(CMakePackage, Key4hepPackage):
     """Acts tracking components for the key4hep project"""
 
     homepage = "https://github.com/key4hep/k4ActsTracking"
@@ -14,3 +14,10 @@ class K4actstracking(BundlePackage, Key4hepPackage):
     version('main', branch='main')
 
     depends_on('acts+dd4hep+tgeo+identification+json')
+    depends_on('gaudi')
+    depends_on('root')
+    depends_on('edm4hep')
+    depends_on('k4fwcore')
+
+    def cmake_args(self):
+        return []


### PR DESCRIPTION
BEGINRELEASENOTES
- k4actstracking now runs a cmake build
- k4actstracking now depends on gaudi, root, edm4hep and k4fwcore

ENDRELEASENOTES
