### PR TITLE
Add environment/pipeline for CI builds spanning multiple PRs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,9 +1,15 @@
 # for compatibility with old git versions on centos
 variables:
   GIT_STRATEGY: clone
-  K4_JOBTYPE: Release
-  K4_CI_URLS: ""
-  SPACK_VERSION: ""
+  K4_JOBTYPE:
+    value: CI
+    description: "Possible Values: Release, Nighlies, CI. A Release job is deployed to sw.hsf.org and uses the latest tags. A Nightlies job is deployed to sw-nightlies.hsf.org and uses the HEAD of the defined repos. A CI build is like a nightly build, but not deployed, and builds local checkouts of the PRs given in K4_CI_URLS"
+  K4_CI_URLS:
+    value: ""
+    description: "A whitespace-separated list of urls for github prs (for repositories for which there is a spack recipe). Example: https://github.com/iLCSoft/SIO/pull/17/ https://github.com/AIDASoft/podio/pull/287"
+  SPACK_VERSION:
+    value: ""
+    description: "A git ref to check out after cloning the spack repository. Leaving this blank will use the latest HEAD (recommended)."
 
 stages:
     - prepare-spack

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,7 @@
 variables:
   GIT_STRATEGY: clone
   K4_JOBTYPE: Release
+  K4_CI_URLS: ""
   SPACK_VERSION: ""
 
 stages:
@@ -33,6 +34,63 @@ setup_spack_push:
             - key4hep-spack_centos7-cvmfs.tar.gz
             - spack 
         expire_in: 1 month
+
+#### CI builds of key4hep-stack
+# This is intended to run more complex ci builds, possibly comprising PRs in several repos
+# this job expects the following setup on the runner:
+# * environment variables GITHUB_TOKEN and GITHUB_USER
+#   set in .bashrc or via gitlab ci - to be able to query the commits on github
+#  
+build-spack-ci:
+    stage: compilation
+    tags:
+        - cvmfs
+    needs:
+        - "setup_spack_push"
+    parallel:
+        matrix:
+          - SPACKENV: 
+            - key4hep-ci
+    only:
+      refs:
+          - schedules # Only execute this on scheduled pipelines
+      variables:
+          - $K4_JOBTYPE == "CI"
+    script:
+        - |
+          #set up spack inside the k4-spack repo
+          source spack/share/spack/setup-env.sh
+          export KEY4HEP_RELEASE_VERSION=master-ci-`date -I`
+          python scripts/fetch_nightly_versions.py >> environments/$SPACKENV/spack.yaml
+          cd environments/$SPACKENV
+          source setup_clingo_centos7.sh
+          spack env activate .
+          spack repo add ../..
+          git clone https://gitlab.cern.ch/sft/sft-spack-repo.git
+          spack repo add ./sft-spack-repo
+          spack add key4hep-stack@${KEY4HEP_RELEASE_VERSION}
+          for K4_CI_URL in $K4_CI_URLS; do
+            # setup development repos
+            export PR_NUMBER=`echo $K4_CI_URL | grep -oP "pull/\K[0-9]*"`
+            export PR_REPO_URL=`echo $K4_CI_URL | grep -oP "\K.*/pull/"`
+            export PR_REPO_URL=`echo ${PR_REPO_URL/\/pull\//}`
+            export PACKAGE_NAME=`echo ${PR_REPO_URL} | rev | cut -d "/" -f -1 | rev `
+            export PACKAGE_NAME=`echo $PACKAGE_NAME |  tr '[:upper:]' '[:lower:]'`
+            echo "PACKAGE_NAME: ${PACKAGE_NAME}"
+            echo "PR_NUMBER: ${PR_NUMBER}"
+            echo "PR_REPO_URL: ${PR_REPO_URL}"
+            #sed -i "/${PACKAGE_NAME}@commit/d" ./spack.yaml
+            mkdir $PACKAGE_NAME; cd $PACKAGE_NAME
+            git clone $PR_REPO_URL .
+            #spack add ${PACKAGE_NAME}@commit.`git rev-parse HEAD`
+            spack develop -p $PWD ${PACKAGE_NAME}@commit.`git rev-parse HEAD`
+            git fetch origin pull/${PR_NUMBER}/head:testbranch${PR_NUMBER}
+            git checkout testbranch${PR_NUMBER}
+            cd ..
+          done;
+          spack concretize -f --test=root --reuse
+          # compile onwards and upwards
+          spack install --test=root --reuse --no-check-signature
 
 #### Nightly build of key4hep-stack
 # this job expects the following setup on the runner:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,6 +30,7 @@ setup_spack_push:
           - pushes
           - merge_requests
           - schedules
+          - web
     script:
         # set up spack inside the k4-spack repo
         - source scripts/ci_setup_spack.sh
@@ -59,7 +60,7 @@ build-spack-ci:
             - key4hep-ci
     only:
       refs:
-          - schedules # Only execute this on scheduled pipelines
+          - web
       variables:
           - $K4_JOBTYPE == "CI"
     script:

--- a/environments/key4hep-ci/compilers.yaml
+++ b/environments/key4hep-ci/compilers.yaml
@@ -1,0 +1,1 @@
+../key4hep-common/compilers.yaml

--- a/environments/key4hep-ci/geant4-data.yaml
+++ b/environments/key4hep-ci/geant4-data.yaml
@@ -1,0 +1,1 @@
+../geant4-data-share/geant4-data.yaml

--- a/environments/key4hep-ci/key4hep-config-nightlies.yaml
+++ b/environments/key4hep-ci/key4hep-config-nightlies.yaml
@@ -1,0 +1,1 @@
+../key4hep-common/config-nightlies.yaml

--- a/environments/key4hep-ci/key4hep-packages.yaml
+++ b/environments/key4hep-ci/key4hep-packages.yaml
@@ -1,0 +1,1 @@
+../key4hep-common/packages.yaml

--- a/environments/key4hep-ci/setup_clingo_centos7.sh
+++ b/environments/key4hep-ci/setup_clingo_centos7.sh
@@ -1,0 +1,1 @@
+../key4hep-common/setup_clingo_centos7.sh

--- a/environments/key4hep-ci/spack.yaml
+++ b/environments/key4hep-ci/spack.yaml
@@ -1,0 +1,28 @@
+spack:
+  upstreams:
+    spack-instance-1:
+      install_tree: /cvmfs/sw-nightlies.hsf.org/spackages5
+    spack-instance-1:
+      install_tree: /cvmfs/sw.hsf.org/spackages5
+  view: false
+  include:
+  - key4hep-config-nightlies.yaml
+  - key4hep-packages.yaml
+  - compilers.yaml
+  packages:
+    qhull:
+      variants: build_type=Release
+    ftgl:
+      variants: build_type=Release
+    cepcsw:
+      variants: build_type=Release
+    all:
+      compiler: [gcc@11.2.0]
+  config:
+    checksum: false
+    install_tree:
+      root: $spack/opt/spack
+      projections:
+        all: ${PACKAGE}/${VERSION}/${target}-${os}-${COMPILERNAME}${COMPILERVER}-opt/${HASH:5}
+        build_type=Debug: ${PACKAGE}/${VERSION}/${target}-${os}-${COMPILERNAME}${COMPILERVER}-dbg/${HASH:5}
+  concretization: together


### PR DESCRIPTION
Usage: Trigger the k4-ci-test schedule on [gitlab](https://gitlab.cern.ch/key4hep/k4-deploy/-/pipeline_schedules), editing it to set the desired value of the `K4_CI_URLS` variable. This should be a whitespace-separated list of the urls of PRs that should be used in the build, example: 
```
K4_CI_URLS=https://github.com/iLCSoft/SIO/pull/17/ https://github.com/AIDASoft/podio/pull/287
```
The `K4_JOBTYPE` must be CI, which is already set in the schedule

Example build: https://gitlab.cern.ch/key4hep/k4-deploy/-/jobs/23356045

Improvements (left for future PRs):
- report status back to github
- better way to trigger build (from github?)
- Currently this uses shared runners for efficiency, making it cumbersome to access  log files. These should be saved as artifacts in case of errors.
