### PR TITLE
lock k4actstracking to acts v19.6.0 for now

### DIFF
--- a/packages/k4actstracking/package.py
+++ b/packages/k4actstracking/package.py
@@ -13,7 +13,7 @@ class K4actstracking(CMakePackage, Key4hepPackage):
 
     version('main', branch='main')
 
-    depends_on('acts+dd4hep+tgeo+identification+json')
+    depends_on('acts+dd4hep+tgeo+identification+json@v19.6.9')
     depends_on('gaudi')
     depends_on('root')
     depends_on('edm4hep')


### PR DESCRIPTION
ACTS main recently updated minimum DD4hep version to 1.21, which hasn't been propagated to the ACTS spack package yet.


BEGINRELEASENOTES
- lock k4actstracking to acts v19.6.0

ENDRELEASENOTES
