### PR TITLE
evtgen: build with tauola support

### DIFF
--- a/packages/k4simdelphes/package.py
+++ b/packages/k4simdelphes/package.py
@@ -39,7 +39,7 @@ class K4simdelphes(CMakePackage, Ilcsoftpackage):
     depends_on('delphes@3.4.3pre10:', when='@:00-01-07', type=('build', 'link', 'run'))
     depends_on('delphes@3.5:', when='@00-01-08:', type=('build', 'link', 'run'))
     depends_on('pythia8', when="+delphes_pythia")
-    depends_on('evtgen+pythia8', when="+delphes_pythia_evtgen")
+    depends_on('evtgen+pythia8+tauola', when="+delphes_pythia_evtgen")
     depends_on('hepmc', when="+delphes_hepmc")
     depends_on('hepmc3', when="+framework")
     depends_on('k4fwcore', when="+framework")

--- a/packages/key4hep-stack/package.py
+++ b/packages/key4hep-stack/package.py
@@ -83,6 +83,7 @@ class Key4hepStack(BundlePackage, Key4hepPackage):
     depends_on('lhapdf', when='+generators')
     depends_on('sherpa', when='+generators')
     depends_on('photos+hepmc3', when='+generators')
+    depends_on('evtgen+pythia8+tauola', when='+generators')
 
     ############################### ilcsoft ###############
     #######################################################


### PR DESCRIPTION
Even if not specifically requested, evtgen otherwise may print the message `EvtGen:EvtAbsExternalGen::getGenerator: could not find generator for genId = 2`
