### PR TITLE
Fix CI pipeline workflow

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -103,7 +103,7 @@ build-spack-ci:
             cd ..
           done;
           # compile onwards and upwards
-          spack install ${SPACK_INSTALL_ARGUMENTS
+          spack install ${SPACK_INSTALL_ARGUMENTS}
 
 #### Nightly build of key4hep-stack
 # this job expects the following setup on the runner:


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix a typo in the CI pipeline workflow

ENDRELEASENOTES

Currently this workflow breaks very early: https://gitlab.cern.ch/key4hep/k4-deploy/-/jobs/24668374#L275