### PR TITLE
key4hep-stack: add gcovr tool

### DIFF
--- a/packages/key4hep-stack/package.py
+++ b/packages/key4hep-stack/package.py
@@ -112,6 +112,7 @@ class Key4hepStack(BundlePackage, Key4hepPackage):
     depends_on('py-ipython', when='+devtools')
     depends_on('doxygen', when='+devtools')
     #depends_on('prmon', when='+devtools')
+    depends_on('py-gcovr', when='+devtools')
     depends_on('py-pip', when='+devtools')
     depends_on('py-particle', when='+devtools')
     depends_on('py-awkward', when='+devtools')


### PR DESCRIPTION
Code coverage tool, recently used in the guinea-pig ci and probably useful in other repositories
