### PR TITLE
KKMCee 5: Patch exporting 'spin' information as hepmc3 attribute

### DIFF
--- a/packages/kkmcee/KKMCee-5.00.01.patch4
+++ b/packages/kkmcee/KKMCee-5.00.01.patch4
@@ -1,0 +1,27 @@
+--- SRCee/TauPair.cxx.orig	2022-05-17 12:46:31.000000000 +0200
++++ SRCee/TauPair.cxx	2022-08-04 17:46:06.285344362 +0200
+@@ -193,6 +193,24 @@
+   wt = wt1;                         // why not wt2???
+   rn = m_RNgen->Rndm();
+   if (wt < wtmax*rn  && loop<100) goto e1099;
++  // Save helicity information in the HepMC3 record as particle (Tau, Tau-) attributes
++  if (m_Hvent) {
++    std::vector<float> hel;
++    for (auto p: m_Hvent->particles()){
++      if (p->pid() == 15){ // Tau-
++        hel.clear(); for(int i=0; i<3;i++) hel.push_back(m_HvClone2[i]);
++        // Create attribute
++        p->add_attribute("spin", std::make_shared<VectorFloatAttribute>(hel));
++      } else if (p->pid() == -15){ // Tau+
++        hel.clear(); for(int i=0; i<3;i++) hel.push_back(m_HvClone1[i]);
++        // Create attribute
++        p->add_attribute("spin", std::make_shared<VectorFloatAttribute>(hel));
++      }
++    }// end loop over particles
++  } else {
++     cout << "m_Hvent not defined! Cannot save helicity information" << endl;
++  }
++
+ }//ImprintSpin
+ 
+ ///______________________________________________________________________________________

--- a/packages/kkmcee/package.py
+++ b/packages/kkmcee/package.py
@@ -35,6 +35,7 @@ class Kkmcee(AutotoolsPackage):
     patch('KKMCee-5.00.01.patch1', level=0, when='@5:')
     patch('KKMCee-5.00.01.patch2', level=0, when='@5:')
     patch('KKMCee-5.00.01.patch3', level=0, when='@5:')
+    patch('KKMCee-5.00.01.patch4', level=0, when='@5:')
 
     patch('KKMCee-dev-4.30.patch', level=0, when='@:4.30')
     patch('KKMCee-dev-4.32.01.patch', level=0, when='@4.31:4.32.01')


### PR DESCRIPTION
BEGINRELEASENOTES
- This pull request adds a 4th (forgotten) patch to export particle spin information as HEPMC3 attribute 'spin', compatible with the modification already introduced in k4Gen HepMCToEDMConverter::convert function. This is required to save the tau polarization in ditau events.
ENDRELEASENOTES
