### PR TITLE
Add latest tags for iLCSoft packages

### DIFF
--- a/packages/ilcutil/package.py
+++ b/packages/ilcutil/package.py
@@ -16,6 +16,7 @@ class Ilcutil(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
+    version("1.7", sha256="08148c374d0b204999bc02c61448a0273489f5031d7a027f2881796c94e040bf")
     version('1.6.2', sha256='2bb018f8cca4ca2480ba00c1f16100e62094fa6f9a0f07d2ba3a3dc274e32f3c')
     version('1.6.1', sha256='cb51f110c0c7b6e5732ab66d49b4658c56bb5944c1540f1563612ac56bb70823')
     version('1.6', sha256='09083890721704f39a3e902dc660db5326027cc38446b813233d04ec3233ba2e')

--- a/packages/ildperformance/package.py
+++ b/packages/ildperformance/package.py
@@ -16,6 +16,7 @@ class Ildperformance(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
+    version("1.11", sha256="8445e68fd1a20d76f15d615dcc3a9044d1829d91e3b7cedac3eafdf098c957ee")
     version('1.10', sha256='5dc9b20af8018d2268df02d05a7245ca8087365a404fd9c3a110484235f7d383')
     version('1.9', sha256='3a8187036eee39b35e4a58d874fa906182a7b83e1d143811ec7d721ea405f3dc')
     version('1.8', sha256='bcf19d3a6f425fa5eea228676d07558635881a0329c4d66ffda4230dfe9617c1')

--- a/packages/kitrackmarlin/package.py
+++ b/packages/kitrackmarlin/package.py
@@ -17,6 +17,7 @@ class Kitrackmarlin(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
+    version("1.13.2", sha256="264c3d1b289091dc76edc2441486c8eb0b6221171f77d51df5a6bbf3b4dd270a")
     version('1.13.1', sha256='3dabd7a0a9ba9aba7c5ef17809dbe6a6e55b1200b33cf12567d0e3e3e91dd15f')
     version('1.13', sha256='1307578313673fae159aa6fb4eacf3f22bfa085c61337d14a5895e078a8d7f70')
 

--- a/packages/lcgeo/package.py
+++ b/packages/lcgeo/package.py
@@ -18,6 +18,7 @@ class Lcgeo(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
+    version("0.18", sha256="04e13129cb3ebcba5ad43b5c001a4049d91da0fe6c24e352e75f49f74e623526")
     version("0.17", sha256="97b18a877304b34d38af333a4817c16602888d36220e21eba74f0f82aae25f2a")
     version('0.16.8', sha256='e729e678a2a2105b58b30b0110cc910edb95e02c8b6babbb9f8d74041d5a0c55')
     version('0.16.7', tag='v00-16-07')

--- a/packages/marlin/package.py
+++ b/packages/marlin/package.py
@@ -16,6 +16,8 @@ class Marlin(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
+    version("1.19", sha256="e3a109da04efb6f0ce904aba864fe8ce4dcfaaa6f910a68374ca499efc4a14dd")
+    version("1.18", sha256="e556302fb6cc48b999a011122479dd51c9e99f6a256771e4a5a154040c7fa2dc")
     version('1.17.1', sha256='b928c6072bbf8db5fdb3b9716227b8724dfc90182967212cd9f2f51ceb760dd0')
     version('1.17', sha256='076acc3a91b7e2e253f338395a8e56bf00498e6aa1a118d3e7bde84f1065d3d6')
 
@@ -39,6 +41,7 @@ class Marlin(CMakePackage, Ilcsoftpackage):
     depends_on("ilcutil")
     depends_on("gear")
     depends_on("lcio")
+    depends_on("lcio@2.19:", when="@1.19:")
     depends_on("doxygen", when="+doc")
     depends_on("qt@:4.99.99", when="+gui")
     depends_on("lccd", when="+lccd")

--- a/packages/marlindd4hep/package.py
+++ b/packages/marlindd4hep/package.py
@@ -17,6 +17,7 @@ class Marlindd4hep(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
+    version("0.6.2", sha256="0229b2990c955f1302fd289ccf564dbbab728a108e6e9e3016259d4b90acd43f")
     version('0.6.1', sha256='1599ee85314d2d22286423092222d99d68ee09a304415f91babccdc8b44d338b')
     version('0.6', sha256='1cf8eb03bbdf6da8fbf277d8168d97f77e1675850a7e66d0e9f90684e3a2f077')
 

--- a/packages/marlinreco/package.py
+++ b/packages/marlinreco/package.py
@@ -16,6 +16,7 @@ class Marlinreco(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
+    version("1.33.1", sha256="2c89954a3a83909e5da069ce223c3d5bd25bd911b7415a219456fbbed13953b8")
     version('1.33', sha256='4f5a9c091c26d67b6be6b1cf2fc1fd57445302a4f817a4aea021c51a3fdc7424')
     version('1.32', sha256='0ea3bee03e2bec1924b5876675043b592a942bc8cf306eb7056eaf03ac1748f6')
     version('1.31', sha256='eeb823f2476e1d31a54997b1a09fcc20cc8f3555a9f677054eacd5f44d4f59ee')

--- a/packages/marlintrkprocessors/package.py
+++ b/packages/marlintrkprocessors/package.py
@@ -17,6 +17,7 @@ class Marlintrkprocessors(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
+    version("2.12.2", sha256="862ed161a882f6b3bc14033be8a38fa9a126594da3774194092adb1c69a0b5e5")
     version('2.12.1', sha256='677532d8d7c9a8489be091d249c8893e2bfb66c78d0e1537cafff97456a00bf5')
     version('2.12', sha256='ac1a3af380c837868649c8b7767e7641d25a1ecf40690726d55a9bcc58a54640')
     version('2.11', sha256='49a567831e2b7a0c43ded955ce31fbe7d467a59960f4bcc2c2120e20762639b0')

--- a/packages/marlinutil/package.py
+++ b/packages/marlinutil/package.py
@@ -19,6 +19,7 @@ class Marlinutil(CMakePackage, Ilcsoftpackage):
     maintainers = ['vvolkl']
 
     version('master', branch='master')
+    version("1.17", sha256="0ac4f4b6b62cf5baeda4f585e205c0a77f55bafd7b968b1a664d5a7535ca3875")
     version('1.16.2', sha256='1dbed3ad127da340b816cda500515b267f26614ec21e9f70fa44ca52eb401803')
     version('1.16.1', sha256='f8e03cba4144b9797fa01321aeb1c2f01967d1fcb10089e7b1765c32e4346508')
     version('1.16', sha256='7f80a726e3b08653a88487b87618fca277d59fe22a448ce15043f8495f1108e9')


### PR DESCRIPTION
BEGINRELEASENOTES
- Add the latest tags for the iLCSoft packages, that will be used in v02-03-01

ENDRELEASENOTES

- [ ] Still need to push the updated recipes for the packages living in central spack