### PR TITLE
Add latest tags for marlin wrapper and converters

### DIFF
--- a/packages/k4edm4hep2lcioconv/package.py
+++ b/packages/k4edm4hep2lcioconv/package.py
@@ -17,6 +17,7 @@ class K4edm4hep2lcioconv(CMakePackage, Key4hepPackage):
     maintainers = ['fdplacido']
 
     version('master', branch='master')
+    version("00-03", sha256="381fd96e2ede03bec048afaeef13b8efffe80030fc097fe18fae62b03c0fba94")
     version('00-02-01', sha256='747066a7f060c4ce6136c1636f90f5f8a20cfb0c474258cbf92cd1a1c28ee394')
     version('00-02', sha256='b9478ed8811bb99103df387db1e2a2cc97bb8d31a6d7b9bf17e6ba6f8ebef153')
     version('00-01', sha256='a1eb60337033658888c637af7c4c57622513a708834fb8a67e6b984614b45748')

--- a/packages/k4marlinwrapper/package.py
+++ b/packages/k4marlinwrapper/package.py
@@ -15,6 +15,7 @@ class K4marlinwrapper(CMakePackage, Ilcsoftpackage):
     maintainers = ['fdplacido']
 
     version('master', branch='master')
+    version("0.5", sha256="080f86700fd141b288878688a5c8f14fe48f1247a4fa1ce37147f528484e826a")
     version('0.4.2', sha256='8ec51ba4e0348d67377179e9d3e9043267a42a0d360d884c331ce52c51b61b03')
     version('0.4.1', sha256='7e3c76bd21a2f2bea196fcae270e29e26ed2abc8d70a4c3d37ce88bacbd22528')
     version('0.4', sha256='6609dacb158f8fd2f8532e0881b0acb73ea23f31578eab44085876a8a59a5946')


### PR DESCRIPTION
BEGINRELEASENOTES
- Add the latest tags of `k4MarlinWrapper` and `k4EDM4hep2LcioConv` for a new release.

ENDRELEASENOTES
