### PR TITLE
Add h5py package to key4hep stack for HDF5 file reading

### DIFF
--- a/packages/key4hep-stack/package.py
+++ b/packages/key4hep-stack/package.py
@@ -120,6 +120,7 @@ class Key4hepStack(BundlePackage, Key4hepPackage):
     depends_on('py-uproot', when='+devtools')
     depends_on('py-pandas', when='+devtools')
     depends_on('py-scipy', when='+devtools')
+    depends_on('py-h5py', when='+devtools')
 
     depends_on('py-scikit-learn', when='+devtools')
     depends_on('xgboost', when='+devtools')


### PR DESCRIPTION
BEGINRELEASENOTES
- Add `h5py` package for HDF5 reading capabilities with python.

ENDRELEASENOTES

Requested from DESY users that start from hdf5 files and want to convert that to e.g. LCIO via python.