### PR TITLE
aidatt: Use cxxstd from root and don't override it

### DIFF
--- a/packages/aidatt/package.py
+++ b/packages/aidatt/package.py
@@ -26,5 +26,6 @@ class Aidatt(CMakePackage, Ilcsoftpackage):
     def cmake_args(self):
         # C++ Standard
         return [
-            '-DCMAKE_CXX_STANDARD=%s' % self.spec['root'].variants['cxxstd'].value
+            '-DCMAKE_CXX_STANDARD=%s' % self.spec['root'].variants['cxxstd'].value,
+            "-DUSE_CXX11=FALSE",  # avoid overriding the root standard
         ]


### PR DESCRIPTION
BEGINRELEASENOTES
- Make sure that `aidatt` does not accidentally override the provided root c++ standard

ENDRELEASENOTES
