### PR TITLE
fccanalyses: put vdt on ROOT_INCLUDE_PATH

### DIFF
--- a/packages/fccanalyses/package.py
+++ b/packages/fccanalyses/package.py
@@ -65,6 +65,8 @@ class Fccanalyses(CMakePackage, Key4hepPackage):
     # todo: update the cmake config to remove this
     def setup_build_environment(self, spack_env):
       spack_env.prepend_path('PYTHONPATH', self.prefix.python) # todo: remove
+      spack_env.prepend_path('ROOT_INCLUDE_PATH', self.spec['vdt'].prefix.include)
+
       if self.spec.satisfies("@:0.6.0"):
           python_version = self.spec['python'].version.up_to(2)
           awk_lib_dir = self.spec['py-awkward'].prefix.lib


### PR DESCRIPTION
On Ubuntu 22.04 it seems to be necessary to have `vdt` on the `ROOT_INCLUDE_PATH` to successfully build fccanalyses (`@0.7.0`). Otherwise it gets stuck on some genreflex step.
