### PR TITLE
[wip] Add an environment for building on Ubuntu 22.04

### DIFF
--- a/environments/key4hep-ubuntu22.04-local/packages.yaml
+++ b/environments/key4hep-ubuntu22.04-local/packages.yaml
@@ -1,0 +1,1 @@
+../key4hep-common/packages.yaml

--- a/environments/key4hep-ubuntu22.04-local/spack.yaml
+++ b/environments/key4hep-ubuntu22.04-local/spack.yaml
@@ -1,0 +1,18 @@
+spack:
+  view: false
+  concretizer:
+    unify: true
+
+  include:
+    - packages.yaml
+
+  packages:
+    all:
+      providers:
+        gl: [mesa]
+        glu: [mesa]
+      compiler: [gcc@11.3.0]
+  specs:
+    - key4hep-stack
+    - python@3.10.10 # workaround https://github.com/spack/spack/issues/32662
+    - lhapdf ~python # workaround https://github.com/spack/spack/issues/36772


### PR DESCRIPTION
This adds an environment definition to build the `key4hep-stack` on Ubuntu 22.04. I marked it as WIP as it still requires a few upstream PRs to be merged as well as some in this repository. However, with all that in place I was able to build this against `spack@develop`
