### PR TITLE
Revert to the old maintainers format

### DIFF
--- a/packages/k4edm4hep2lcioconv/package.py
+++ b/packages/k4edm4hep2lcioconv/package.py
@@ -15,7 +15,7 @@ class K4edm4hep2lcioconv(CMakePackage, Key4hepPackage):
     git = "https://github.com/key4hep/k4EDM4hep2LcioConv.git"
     url = "https://github.com/key4hep/k4EDM4hep2LcioConv/archive/v00-01.zip"
 
-    maintainers("tmadlener")
+    maintainers = ["tmadlener"]
 
     version("master", branch="master")
     version(

--- a/packages/k4lcioreader/package.py
+++ b/packages/k4lcioreader/package.py
@@ -8,7 +8,7 @@ class K4lcioreader(CMakePackage, Key4hepPackage):
     url = "https://github.com/key4hep/k4LCIOReader/archive/v0.1.0.tar.gz"
     git = "https://github.com/key4hep/k4LCIOReader.git"
 
-    maintainers("mirguest")
+    maintainers = ["mirguest"]
 
     version("master", branch="master")
     version(

--- a/packages/k4marlinwrapper/package.py
+++ b/packages/k4marlinwrapper/package.py
@@ -13,7 +13,7 @@ class K4marlinwrapper(CMakePackage, Ilcsoftpackage):
     git = "https://github.com/key4hep/k4MarlinWrapper.git"
     url = "https://github.com/key4hep/k4MarlinWrapper/archive/v00-01.tar.gz"
 
-    maintainers("tmadlener", "jmcarcell")
+    maintainers = ["tmadlener", "jmcarcell"]
 
     version("master", branch="master")
     version(

--- a/packages/k4simdelphes/package.py
+++ b/packages/k4simdelphes/package.py
@@ -14,7 +14,7 @@ class K4simdelphes(CMakePackage, Ilcsoftpackage):
     git = "https://github.com/key4hep/k4SimDelphes.git"
     url = "https://github.com/key4hep/k4SimDelphes/archive/v00-00-01.tar.gz"
 
-    maintainers("vvolkl", "tmadlener")
+    maintainers = ["vvolkl", "tmadlener"]
 
     version("main", branch="main")
     version(

--- a/packages/raida/package.py
+++ b/packages/raida/package.py
@@ -13,7 +13,7 @@ class Raida(CMakePackage, Ilcsoftpackage):
     git = "https://github.com/iLCSoft/raida.git"
     url = "https://github.com/iLCSoft/raida/archive/v01-06.tar.gz"
 
-    maintainers("vvolkl")
+    maintainers = ["vvolkl"]
 
     version("master", branch="master")
     version(


### PR DESCRIPTION
Causes issues with the current spack releases, see https://github.com/key4hep/key4hep-spack/issues/472