### PR TITLE
Add a GUI capable default backend to matplotlib

### DIFF
--- a/environments/key4hep-common/packages.yaml
+++ b/environments/key4hep-common/packages.yaml
@@ -140,6 +140,12 @@ packages:
     target: []
     providers: {}
     compiler: []
+  matplotlib:
+    variants: backend=qt5agg
+    version: []
+    target: []
+    providers: {}
+    compiler: []
   all:
     target: [x86_64]
     variants: build_type=Release cxxstd=17


### PR DESCRIPTION
BEGINRELEASENOTES
- Add a GUI capable default backend to matplotlib (`qt5agg`) to make it work interactively. Fixes #474

ENDRELEASENOTES

I have chosen `qt5agg` because we already have `qt@5` in the stack in any case and this just adds `py-pyqt5` as additional dependency.