### PR TITLE
key4hep-stack: bump minimal catch2 version

### DIFF
--- a/packages/key4hep-stack/package.py
+++ b/packages/key4hep-stack/package.py
@@ -83,7 +83,7 @@ class Key4hepStack(BundlePackage, Key4hepPackage):
 
     depends_on('cepcsw')
     
-    depends_on('catch2@3.1:', when='+devtools')
+    depends_on('catch2@3:', when='+devtools')
     depends_on('cmake', when='+devtools')
     depends_on('doxygen', when='+devtools')
     depends_on('gdb', when='+devtools')

--- a/packages/key4hep-stack/package.py
+++ b/packages/key4hep-stack/package.py
@@ -83,7 +83,7 @@ class Key4hepStack(BundlePackage, Key4hepPackage):
 
     depends_on('cepcsw')
     
-    depends_on('catch2@3.0.1:', when='+devtools')
+    depends_on('catch2@3.1:', when='+devtools')
     depends_on('cmake', when='+devtools')
     depends_on('doxygen', when='+devtools')
     depends_on('gdb', when='+devtools')


### PR DESCRIPTION
Will become necessary with https://github.com/AIDASoft/podio/pull/402