### PR TITLE
Build HDF5 with c++ bindings and the high level interface

### DIFF
--- a/environments/key4hep-common/packages.yaml
+++ b/environments/key4hep-common/packages.yaml
@@ -61,8 +61,7 @@ packages:
   gperftools:
     variants: ~libunwind
   hdf5:
-    variants: +cxx+hl
-    require: "+cxx+hl"
+    require: +cxx+hl
   all:
     target: [x86_64]
     variants: build_type=Release cxxstd=17

--- a/environments/key4hep-common/packages.yaml
+++ b/environments/key4hep-common/packages.yaml
@@ -60,6 +60,9 @@ packages:
     variants: ~openmp
   gperftools:
     variants: ~libunwind
+  hdf5:
+    variants: +cxx+hl
+    require: "+cxx+hl"
   all:
     target: [x86_64]
     variants: build_type=Release cxxstd=17


### PR DESCRIPTION
Necessary for building the LUXE simulation that currently produces HDF5 output.

Not sure if we can already use `require` for the release.