### PR TITLE
Change LCGEO and K4GEO to point to /share/k4geo

### DIFF
--- a/packages/k4geo/package.py
+++ b/packages/k4geo/package.py
@@ -86,8 +86,8 @@ class K4geo(CMakePackage):
         install_tree("SiD", self.prefix.share.k4geo.compact.Sid)
 
     def setup_run_environment(self, env):
-        env.set("LCGEO", self.prefix.share.k4geo.compact)
-        env.set("K4GEO", self.prefix.share.k4geo.compact)
+        env.set("LCGEO", self.prefix.share.k4geo)
+        env.set("K4GEO", self.prefix.share.k4geo)
         env.set("lcgeo_DIR", self.prefix.share.k4geo.compact)
         env.set("k4geo_DIR", self.prefix.share.k4geo.compact)
         env.prepend_path("LD_LIBRARY_PATH", self.spec["k4geo"].prefix.lib)


### PR DESCRIPTION
BEGINRELEASENOTES
- Change LCGEO and K4GEO to point to /share/k4geo, after it has been changed in k4geo

ENDRELEASENOTES

This is needed after https://github.com/key4hep/k4geo/pull/284