### PR TITLE
Add a compact variant to k4geo

### DIFF
--- a/packages/k4geo/package.py
+++ b/packages/k4geo/package.py
@@ -50,10 +50,7 @@ class K4geo(CMakePackage):
         description="Use the specified C++ standard when building.",
     )
 
-    variant("compact",
-            default=True,
-            description="Install compact files"
-    )
+    variant("compact", default=True, description="Install compact files")
 
     depends_on("lcio")
     depends_on("dd4hep")

--- a/packages/k4geo/package.py
+++ b/packages/k4geo/package.py
@@ -50,6 +50,11 @@ class K4geo(CMakePackage):
         description="Use the specified C++ standard when building.",
     )
 
+    variant("compact",
+            default=True,
+            description="Install compact files"
+    )
+
     depends_on("lcio")
     depends_on("dd4hep")
     depends_on("lcio")
@@ -72,18 +77,9 @@ class K4geo(CMakePackage):
     def cmake_args(self):
         args = []
         args.append(self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"))
+        args.append(self.define_from_variant("INSTALL_COMPACT_FILES", "compact"))
         args.append(self.define("BUILD_TESTING", self.run_tests))
         return args
-
-    @run_after("install")
-    def install_compact(self):
-        install_tree("CaloTB", self.prefix.share.k4geo.CaloTB)
-        install_tree("CLIC", self.prefix.share.k4geo.CLIC)
-        install_tree("FCalTB", self.prefix.share.k4geo.FCalTB)
-        install_tree("FCCee", self.prefix.share.k4geo.FCCee)
-        install_tree("fieldmaps", self.prefix.share.k4geo.fieldmaps)
-        install_tree("ILD", self.prefix.share.k4geo.ILD)
-        install_tree("SiD", self.prefix.share.k4geo.Sid)
 
     def setup_run_environment(self, env):
         env.set("LCGEO", self.prefix.share.k4geo)


### PR DESCRIPTION
BEGINRELEASENOTES
- Add a compact variant to k4geo that will use the INSTALL_COMPACT_FILES setting

ENDRELEASENOTES

I thought https://github.com/key4hep/key4hep-spack/pull/513 was enough to make it work but apparently we were never using the INSTALL_COMPACT_FILES setting so https://github.com/key4hep/k4geo/pull/284 didn't have any effect