### PR TITLE
packages.yaml: temporarily add acts spec

### DIFF
--- a/environments/key4hep-common/packages.yaml
+++ b/environments/key4hep-common/packages.yaml
@@ -1,6 +1,6 @@
 packages:
   acts:
-    require: +dd4hep+edm4hep
+    require: +dd4hep
   boost:
     require: +python
     buildable: true

--- a/environments/key4hep-common/packages.yaml
+++ b/environments/key4hep-common/packages.yaml
@@ -1,4 +1,6 @@
 packages:
+  acts:
+    require: +dd4hep+edm4hep
   boost:
     require: +python
     buildable: true


### PR DESCRIPTION
Currently the k4ActsTracking package is not build and commented out in key4hep-stack, therefore, ACTS is built with only the requirements from FCCAnalyses. To be able to get k4ActsTracking back up to speed and activated again eventually, I would like to have these two requirements added to the acts spec here. At the moment we can not build k4ActsTracking against key4hep as the DD4hep plugin is missing.

Once k4ActsTracking is in the stack again we can remove this.

BEGINRELEASENOTES
- Temporarily add acts spec to packages.yaml

ENDRELEASENOTES
