### PR TITLE
Remove explicit mentions of older variants

### DIFF
--- a/environments/key4hep-common/packages.yaml
+++ b/environments/key4hep-common/packages.yaml
@@ -55,7 +55,7 @@ packages:
   geant4:
     require: +qt+opengl+vecgeom cxxstd=17
   root:
-    variants: +davix+fftw+gsl+math~memstat+minuit+mlp+opengl~postgres~pythia6+pythia8+python~qt4+r+root7+roofit+rpath~shadow+sqlite+ssl~table+tbb+threads+tmva+unuran+vc+vdt+x+xml+xrootd cxxstd=17 build_type=RelWithDebInfo
+    variants: +davix+fftw+gsl+math+minuit+mlp+opengl~postgres~pythia6+pythia8+python+r+root7+roofit+rpath~shadow+sqlite+ssl+tbb+threads+tmva+unuran+vc+vdt+x+xml+xrootd cxxstd=17 build_type=RelWithDebInfo
   marlin:
     require: +lccd
   py-tensorflow:

--- a/environments/key4hep-common/packages.yaml
+++ b/environments/key4hep-common/packages.yaml
@@ -55,7 +55,7 @@ packages:
   geant4:
     require: +qt+opengl+vecgeom cxxstd=17
   root:
-    variants: +davix+fftw+gsl+math+minuit+mlp+opengl~postgres~pythia6+pythia8+python+r+root7+roofit+rpath~shadow+sqlite+ssl+tbb+threads+tmva+unuran+vc+vdt+x+xml+xrootd cxxstd=17 build_type=RelWithDebInfo
+    require: +davix+fftw+gsl+math+minuit+mlp+opengl~postgres~pythia6+pythia8+python+r+root7+roofit+rpath~shadow+sqlite+ssl+tbb+threads+tmva+unuran+vc+vdt+x+xml+xrootd cxxstd=17 build_type=RelWithDebInfo
   marlin:
     require: +lccd
   py-tensorflow:


### PR DESCRIPTION
Remove a few variants from the root spec that are only available `@:6.17`. I just stumbled over this with `spack@develop` in a local environment. If I switch the `variant` to `require` spack would refuse to concretize if I add `@6.28.06` to the clause, because the variants "do not exist" in that case, and the conretizer is not able to see through that apparently.

Since we are way ahead on root in any case, I think the easiest is to simply remove the three variants here.