### PR TITLE
Add catch2 test dependency for marlinutil and fccanalyses

### DIFF
--- a/packages/fccanalyses/package.py
+++ b/packages/fccanalyses/package.py
@@ -76,6 +76,7 @@ class Fccanalyses(CMakePackage, Key4hepPackage):
     depends_on("py-pyyaml", type=("build", "run"))
     depends_on("py-onnxruntime", when="+onnx")
     depends_on("delphes@3.5.1pre07:", when="@0.7.0:")
+    depends_on("catch2@3:", type=("test"), when="@0.4:")
 
     def cmake_args(self):
         args = [
@@ -85,6 +86,7 @@ class Fccanalyses(CMakePackage, Key4hepPackage):
             self.define_from_variant("WITH_ACTS", "acts"),
             self.define_from_variant("WITH_DD4HEP", "dd4hep"),
             self.define_from_variant("WITH_ONNX", "onnx"),
+            self.define("BUILD_TESTING", self.run_tests),
         ]
         return args
 

--- a/packages/marlinutil/package.py
+++ b/packages/marlinutil/package.py
@@ -51,12 +51,14 @@ class Marlinutil(CMakePackage, Ilcsoftpackage):
     depends_on("ced")
     depends_on("dd4hep")
     depends_on("root")
+    depends_on("catch2@3:", type=("test"), when="@1.17:")
 
     def cmake_args(self):
         spec = self.spec
         cxxstd = spec["root"].variants["cxxstd"].value
         # Make sure that we pick the right GSL
         return [
-            "-DCMAKE_CXX_STANDARD={0}".format(cxxstd),
-            "-DGSL_DIR={}".format(self.spec["gsl"].prefix),
+            self.define("CMAKE_CXX_STANDARD", cxxstd),
+            self.define("GSL_DIR", self.spec["gsl"].prefix),
+            self.define("BUILD_TESTING", self.run_tests),
         ]


### PR DESCRIPTION
I am not sure what exactly changed in spack, but for some reason these failed to get past cmake because `BUILD_TESTING` was no longer set to `OFF` by default. Explicitly adding the `catch2` dependency for tests and making sure to set `BUILD_TESTING` according to whether tests are required or not.

I suppose this also could hit some other packages, but we don't see the effect because they don't need any extra dependencies for the tests.