### PR TITLE
Geant4: do not use vecgeom: 

### DIFF
--- a/environments/key4hep-common/packages.yaml
+++ b/environments/key4hep-common/packages.yaml
@@ -60,7 +60,7 @@ packages:
 
 
   geant4:
-    require: +qt+opengl+vecgeom cxxstd=17
+    require: +qt+opengl~vecgeom cxxstd=17
   root:
     require: +davix+fftw+gsl+math+minuit+mlp+opengl~postgres~pythia6+pythia8+python+r+root7+roofit+rpath~shadow+sqlite+ssl+tbb+threads+tmva+unuran+vc+vdt+x+xml+xrootd cxxstd=17 build_type=RelWithDebInfo
   marlin:


### PR DESCRIPTION

BEGINRELEASENOTES
- Geant4: Build Geant4 without vecgeom: see see https://github.com/key4hep/k4geo/issues/303

ENDRELEASENOTES
