### PR TITLE
Build whizard with HepMC3 support

### DIFF
--- a/environments/key4hep-common/packages.yaml
+++ b/environments/key4hep-common/packages.yaml
@@ -71,7 +71,7 @@ packages:
   py-tensorflow:
     require: ~cuda~nccl
   whizard:
-    variants: ~fastjet~latex+lcio~lhapdf+openloops~openmp+pythia8 hepmc=3
+    require: ~fastjet~latex+lcio~lhapdf+openloops~openmp+pythia8 hepmc=3
   k4simdelphes:
     require: ~delphes_hepmc
   evtgen:

--- a/packages/ilcsoft/package.py
+++ b/packages/ilcsoft/package.py
@@ -33,7 +33,7 @@ class Ilcsoft(BundlePackage, Key4hepPackage):
     # todo: figure out the api for the cern gitlab instance
     # depends_on('guinea-pig@master', when="@master")
 
-    depends_on("whizard +lcio +openloops hepmc=2")
+    depends_on("whizard")
     # todo: figure out the api for the whizard gitlab instance
     # depends_on('whizard@master +lcio +openloops hepmc=2', when="@master")
 

--- a/packages/key4hep-stack/package.py
+++ b/packages/key4hep-stack/package.py
@@ -68,7 +68,7 @@ class Key4hepStack(BundlePackage, Key4hepPackage):
     depends_on("k4geo")
     depends_on("podio")
     depends_on("python~debug")
-    depends_on("whizard +lcio +openloops hepmc=2")
+    depends_on("whizard")
     depends_on("xrootd +krb5")
 
     depends_on("evtgen+pythia8+tauola+photos", when="+generators")

--- a/scripts/run_usability_tests.sh
+++ b/scripts/run_usability_tests.sh
@@ -84,11 +84,16 @@ run_test "DD4hep test" "ddsim --compactFile DD4hep/DDDetectors/compact/SiD.xml -
 # run_test "podio test" "podio-dump muons.slcio"
 # run_test "edm4hep test"
 # run_test "k4fwcore test" "k4run -n 10 --input muons.slcio --output output.slcio --processors k4FWCoreTestProcessor"
+
+# Produce more than one output to make sure that all of the desired output
+# formats are actually available
+# see: https://github.com/key4hep/key4hep-spack/issues/533
+#      https://github.com/key4hep/key4hep-spack/issues/549
 cat > ee.sin <<EOF
     process ee = e1, E1 => e2, E2
     sqrts = 360 GeV
     n_events = 10
-    sample_format = lhef
+    sample_format = lhef, lcio, hepmc
     simulate (ee)
 EOF
 run_test "whizard test" "whizard -r ee.sin"


### PR DESCRIPTION
BEGINRELEASENOTES
- Make sure that we build Whizard with HepMC3 support and add a runtime test that makes sure that LCIO and HepMC support are actually built.

ENDRELEASENOTES

- Fixes #549 
- See also #533
- [ ] https://github.com/spack/spack/pull/41538