### PR TITLE
Updating gcc version for latest ubuntu22

### DIFF
--- a/scripts/cvmfs/setup-nightlies.sh
+++ b/scripts/cvmfs/setup-nightlies.sh
@@ -50,7 +50,7 @@ elif [[ "$(cat /etc/os-release | grep -E '^ID=')" = 'ID=ubuntu' ]]; then
     if [ $? -ne 0 ]; then
       return 1
     fi
-    k4path="/cvmfs/sw-nightlies.hsf.org/key4hep/releases/$rel/x86_64-ubuntu22.04-gcc11.?.0-opt"
+    k4path="/cvmfs/sw-nightlies.hsf.org/key4hep/releases/$rel/x86_64-ubuntu22.04-gcc11.4.0-opt"
 else
     echo "Unsupported OS or OS couldn't be correctly detected, aborting..."
     return 1

--- a/scripts/cvmfs/setup-nightlies.sh
+++ b/scripts/cvmfs/setup-nightlies.sh
@@ -50,7 +50,7 @@ elif [[ "$(cat /etc/os-release | grep -E '^ID=')" = 'ID=ubuntu' ]]; then
     if [ $? -ne 0 ]; then
       return 1
     fi
-    k4path="/cvmfs/sw-nightlies.hsf.org/key4hep/releases/$rel/x86_64-ubuntu22.04-gcc11.3.0-opt"
+    k4path="/cvmfs/sw-nightlies.hsf.org/key4hep/releases/$rel/x86_64-ubuntu22.04-gcc11.?.0-opt"
 else
     echo "Unsupported OS or OS couldn't be correctly detected, aborting..."
     return 1

--- a/scripts/cvmfs/setup-releases.sh
+++ b/scripts/cvmfs/setup-releases.sh
@@ -50,7 +50,7 @@ elif [[ "$(cat /etc/os-release | grep -E '^ID=')" = 'ID=ubuntu' ]]; then
     if [ $? -ne 0 ]; then
       return 1
     fi
-    k4path="/cvmfs/sw.hsf.org/key4hep/releases/$rel/x86_64-ubuntu22.04-gcc11.3.0-opt"
+    k4path="/cvmfs/sw.hsf.org/key4hep/releases/$rel/x86_64-ubuntu22.04-gcc11.4.0-opt"
 else
     echo "Unsupported OS or OS couldn't be correctly detected, aborting..."
     return 1

--- a/scripts/cvmfs/setup-releases.sh
+++ b/scripts/cvmfs/setup-releases.sh
@@ -50,7 +50,7 @@ elif [[ "$(cat /etc/os-release | grep -E '^ID=')" = 'ID=ubuntu' ]]; then
     if [ $? -ne 0 ]; then
       return 1
     fi
-    k4path="/cvmfs/sw.hsf.org/key4hep/releases/$rel/x86_64-ubuntu22.04-gcc11.4.0-opt"
+    k4path="/cvmfs/sw.hsf.org/key4hep/releases/$rel/x86_64-ubuntu22.04-gcc11.?.0-opt"
 else
     echo "Unsupported OS or OS couldn't be correctly detected, aborting..."
     return 1

--- a/scripts/cvmfs/setup-releases.sh
+++ b/scripts/cvmfs/setup-releases.sh
@@ -50,7 +50,7 @@ elif [[ "$(cat /etc/os-release | grep -E '^ID=')" = 'ID=ubuntu' ]]; then
     if [ $? -ne 0 ]; then
       return 1
     fi
-    k4path="/cvmfs/sw.hsf.org/key4hep/releases/$rel/x86_64-ubuntu22.04-gcc11.?.0-opt"
+    k4path="/cvmfs/sw.hsf.org/key4hep/releases/$rel/x86_64-ubuntu22.04-gcc11.4.0-opt"
 else
     echo "Unsupported OS or OS couldn't be correctly detected, aborting..."
     return 1


### PR DESCRIPTION
BEGINRELEASENOTES
- updating GCC version for ubuntu22

ENDRELEASENOTES

Currently stable stack + ubuntu22 fails for FCCAnalyses [[example](https://github.com/HEP-FCC/FCCAnalyses/actions/runs/7180201065/job/19551946075?pr=325)].