### PR TITLE
k4fwcore: avoid using podio >= 0.17.4 for k4FWCore versions which requires EventStore.h

### DIFF
--- a/packages/k4fwcore/package.py
+++ b/packages/k4fwcore/package.py
@@ -39,6 +39,7 @@ class K4fwcore(CMakePackage, Ilcsoftpackage):
     depends_on("podio@0.10:")
     depends_on("podio@0.14.1", when="@1.0pre14:1.0pre15")
     depends_on("podio@0.14.2:", when="@1.0pre16:")
+    depends_on("podio@:0.17.3", when="@:1.0pre17")  # podio/EventStore.h removed
     depends_on("edm4hep")
     depends_on("edm4hep@0.4.1:", when="@1.0pre14:")
     depends_on("edm4hep@0.10.2:", when="@1.0pre17:")


### PR DESCRIPTION
Avoids
```
     85    In file included from /data/spack/stage/wdconinc/spack-stage-k4fwcore-1.0pre17-kslbyzdb5zztfwulvlrzpe3txxrksf7e/spack-src/k4FWCore/src/PodioLegacyDataSvc.cpp:19:
  >> 86    /data/spack/stage/wdconinc/spack-stage-k4fwcore-1.0pre17-kslbyzdb5zztfwulvlrzpe3txxrksf7e/spack-src/k4FWCore/include/k4FWCore/PodioLegacyDataSvc.h:27:10: fatal error: podio/EventStore.h: No such file or directory
     87       27 | #include "podio/EventStore.h"
     88          |          ^~~~~~~~~~~~~~~~~~~~
     89    compilation terminated.
  >> 90    make[2]: *** [k4FWCore/CMakeFiles/k4FWCore.dir/build.make:93: k4FWCore/CMakeFiles/k4FWCore.dir/src/PodioLegacyDataSvc.cpp.o] Error 1
```

BEGINRELEASENOTES
- k4fwcore: avoid using podio >= 0.17.4 for k4FWCore versions which requires EventStore.h

ENDRELEASENOTES
