### PR TITLE
k4fwcore: master is now main

### DIFF
--- a/packages/k4edm4hep2lcioconv/package.py
+++ b/packages/k4edm4hep2lcioconv/package.py
@@ -17,7 +17,7 @@ class K4edm4hep2lcioconv(CMakePackage, Key4hepPackage):
 
     maintainers = ["tmadlener"]
 
-    version("master", branch="master")
+    version("main", branch="main")
     version(
         "00-07",
         sha256="269d14c390f987fb3fdb0d2e952febfb639415bef50e5e1c8992f23e0cd4a5a6",

--- a/packages/k4fwcore/package.py
+++ b/packages/k4fwcore/package.py
@@ -9,7 +9,7 @@ class K4fwcore(CMakePackage, Ilcsoftpackage):
     url = "https://github.com/key4hep/k4FWCore/archive/v00-01.tar.gz"
     git = "https://github.com/key4hep/k4FWCore.git"
 
-    version("master", branch="master")
+    version("main", branch="main")
     version("1.0pre17", tag="v01-00pre17")
     version("1.0pre16", tag="v01-00pre16")
     version("1.0pre15", tag="v01-00pre15")

--- a/packages/k4geo/package.py
+++ b/packages/k4geo/package.py
@@ -15,7 +15,7 @@ class K4geo(CMakePackage):
 
     maintainers = ["jmcarcell"]
 
-    version("master", branch="master")
+    version("main", branch="main")
     version(
         "0.19",
         url="https://github.com/key4hep/k4geo/archive/v00-19-00.tar.gz",

--- a/packages/k4projecttemplate/package.py
+++ b/packages/k4projecttemplate/package.py
@@ -13,7 +13,7 @@ class K4projecttemplate(CMakePackage, Key4hepPackage):
 
     maintainers = ["vvolkl"]
 
-    version("master", branch="master")
+    version("main", branch="main")
     version(
         "0.4.0",
         sha256="e1fb8992f85ba29918e1103d3472e4ca272a16b09819f7d1ed79e6d97c4445a4",


### PR DESCRIPTION
I suppose this is not the only place where master was renamed to main. Whoever did the renaming: feel free to just list the ones here, and I can propagate the changes where needed.

BEGINRELEASENOTES
- rename branch master to main in k4fwcore

ENDRELEASENOTES
