### PR TITLE
Add pylint and flake8 to the stack

### DIFF
--- a/packages/key4hep-stack/package.py
+++ b/packages/key4hep-stack/package.py
@@ -101,6 +101,8 @@ class Key4hepStack(BundlePackage, Key4hepPackage):
     # depends_on('prmon', when='+devtools')
     depends_on("py-awkward", when="+devtools")
     depends_on("py-black", when="+devtools")
+    depends_on("py-flake8", when="+devtools")
+    depends_on("py-pylint", when="+devtools")
     depends_on("py-boto3", when="+devtools")
     depends_on("py-gcovr", when="+devtools")
     depends_on("py-h5py", when="+devtools")


### PR DESCRIPTION
Make it easier to run them from within the stack.

At some point we might want to fix versions, but for now I think things should work without.