### PR TITLE
Add the k4RecTracker package

### DIFF
--- a/packages/k4rectracker/package.py
+++ b/packages/k4rectracker/package.py
@@ -1,7 +1,7 @@
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 from spack.pkg.k4.key4hep_stack import k4_setup_env_for_framework_tests
 
-class K4reco(CMakePackage, Ilcsoftpackage):
+class K4rectracker(CMakePackage, Ilcsoftpackage):
     """Tracking detectors (and similar) digitization and reconstruction using Gaudi in native key4hep"""
 
     homepage = "https://github.com/key4hep/k4RecTracker"

--- a/packages/k4rectracker/package.py
+++ b/packages/k4rectracker/package.py
@@ -1,0 +1,43 @@
+from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
+from spack.pkg.k4.key4hep_stack import k4_setup_env_for_framework_tests
+
+class K4reco(CMakePackage, Ilcsoftpackage):
+    """Tracking detectors (and similar) digitization and reconstruction using Gaudi in native key4hep"""
+
+    homepage = "https://github.com/key4hep/k4RecTracker"
+    url = "https://github.com/key4hep/k4RecTracker/archive/refs/tags/v00-01.tar.gz"
+    git = "https://github.com/key4hep/k4RecTracker.git"
+
+    version("master", branch="main")
+
+    depends_on("root")
+    depends_on("edm4hep")
+    depends_on("k4fwcore")
+    depends_on("gaudi")
+    depends_on("dd4hep")
+
+    def cmake_args(self):
+        args = []
+        # C++ Standard
+        args.append(
+            self.define(
+                "CMAKE_CXX_STANDARD", self.spec["root"].variants["cxxstd"].value
+            )
+        )
+        return args
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        # needed to set up the runtime dependencies for tests
+        env.prepend_path("PYTHONPATH", self.prefix.python)
+        env.prepend_path("LD_LIBRARY_PATH", self.spec["k4rectracker"].prefix.lib)
+        env.prepend_path("LD_LIBRARY_PATH", self.spec["k4rectracker"].prefix.lib64)
+
+    def setup_run_environment(self, env):
+        env.prepend_path("PYTHONPATH", self.prefix.python)
+        env.prepend_path("LD_LIBRARY_PATH", self.spec["k4rectracker"].prefix.lib)
+        env.prepend_path("LD_LIBRARY_PATH", self.spec["k4rectracker"].prefix.lib64)
+
+    def setup_build_environment(self, env):
+        env.prepend_path("LD_LIBRARY_PATH", self.spec["gaudi"].prefix.lib)
+        env.prepend_path("LD_LIBRARY_PATH", self.spec["gaudi"].prefix.lib64)
+        # k4_setup_env_for_framework_tests(self.spec, env)

--- a/packages/k4rectracker/package.py
+++ b/packages/k4rectracker/package.py
@@ -1,6 +1,7 @@
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 from spack.pkg.k4.key4hep_stack import k4_setup_env_for_framework_tests
 
+
 class K4rectracker(CMakePackage, Ilcsoftpackage):
     """Tracking detectors (and similar) digitization and reconstruction using Gaudi in native key4hep"""
 

--- a/packages/key4hep-stack/package.py
+++ b/packages/key4hep-stack/package.py
@@ -85,6 +85,7 @@ class Key4hepStack(BundlePackage, Key4hepPackage):
     depends_on("fccanalyses")
     depends_on("fccdetectors")
     depends_on("k4reccalorimeter")
+    depends_on("k4rectracker")
 
     depends_on("cepcsw")
 

--- a/scripts/fetch_nightly_versions.py
+++ b/scripts/fetch_nightly_versions.py
@@ -158,6 +158,7 @@ if __name__ == "__main__":
         ("k4marlinwrapper", "key4hep/k4marlinwrapper"),
         ("k4projecttemplate", "key4hep/k4-project-template"),
         ("k4reccalorimeter", "hep-fcc/k4reccalorimeter"),
+        ("k4retracker", "key4hep/k4rectracker"),
         ("k4simdelphes", "key4hep/k4SimDelphes"),
         ("k4simgeant4", "hep-fcc/k4simgeant4"),
         ("kaltest", "ilcsoft/kaltest"),


### PR DESCRIPTION
BEGINRELEASENOTES
- Add the k4RecTracker package, hosting edm4hep based Gaudi algorithms for tracking detectors (and similar) digitization and reconstruction

ENDRELEASENOTES
