### PR TITLE
k4fwcore: add versions 1.0pre18, 1.0pre19

### DIFF
--- a/packages/k4fwcore/package.py
+++ b/packages/k4fwcore/package.py
@@ -10,6 +10,8 @@ class K4fwcore(CMakePackage, Ilcsoftpackage):
     git = "https://github.com/key4hep/k4FWCore.git"
 
     version("main", branch="main")
+    version("1.0pre19", tag="v01-00pre19")
+    version("1.0pre18", tag="v01-00pre18")
     version("1.0pre17", tag="v01-00pre17")
     version("1.0pre16", tag="v01-00pre16")
     version("1.0pre15", tag="v01-00pre15")


### PR DESCRIPTION
I don't think any dependencies changed. Main changes:
- 1.0pre18: removes legacy event store, already addressed by current depenencies I think,
- 1.0pre19: removes lcdd, which may lead to downstream package dependency changes (e.g. depends_on k4fwcore@:1.0pre17 when @:$some_version). 

BEGINRELEASENOTES
- add k4fwcore versions 1.0pre18, 1.0pre19

ENDRELEASENOTES
