### PR TITLE
Enable the JSON plugin for ACTS

### DIFF
--- a/environments/key4hep-common/packages.yaml
+++ b/environments/key4hep-common/packages.yaml
@@ -1,6 +1,6 @@
 packages:
   acts:
-    require: +dd4hep cxxstd=20
+    require: +dd4hep cxxstd=20 +json
   boost:
     require: +python
     buildable: true


### PR DESCRIPTION
BEGINRELEASENOTES
- Enable the JSON plugin for ACTS.

ENDRELEASENOTES

This is a requirement for MarlinACTSTracking to build.
