### PR TITLE
k4fwcore: depends_on gaudi +gaudialg when newer gaudi

### DIFF
--- a/packages/k4fwcore/package.py
+++ b/packages/k4fwcore/package.py
@@ -23,6 +23,7 @@ class K4fwcore(CMakePackage, Ilcsoftpackage):
     )
 
     depends_on("gaudi")
+    depends_on("gaudi +gaudialg", when="^gaudi@37:")
     depends_on("root")
     depends_on("podio")
     depends_on("podio@0.14.1", when="@1.0pre14:1.0pre15")


### PR DESCRIPTION
BEGINRELEASENOTES
- k4fwcore uses GaudiAlg, for now, so it should depend on it explicitly

ENDRELEASENOTES
