### PR TITLE
Add support for --help and -h with the setup scripts

### DIFF
--- a/scripts/cvmfs/setup-nightlies.sh
+++ b/scripts/cvmfs/setup-nightlies.sh
@@ -5,7 +5,7 @@
 function usage() {
     echo "Usage: source /cvmfs/sw-nightlies.hsf.org/key4hep/setup.sh [-r <release>] [--list-releases [distribution]] [--list-packages [distribution]]"
     echo "       -r <release> : setup a specific release, if not specified the latest release will be used (also used for --list-packages)"
-    echo "       -h           : print this help message"
+    echo "       --help, -h   : print this help message"
     echo "       --list-releases [distribution] : list available releases for the specified distribution (almalinux, centos, ubuntu). By default (no OS is specified) it will list the releases for the detected distribution"
     echo "       --list-packages [distribution] : list available packages and their versions for the specified distribution (almalinux, centos, ubuntu). By default (no OS is specified) it will list the packages for the detected distribution"
 }
@@ -88,6 +88,10 @@ for ((i=1; i<=$#; i++)); do
     eval arg=\$$i
     eval "argn=\${$((i+1))}"
     case $arg in
+        --help|-h)
+            usage
+            return 0
+            ;;
         --list-releases)
             if [ ! -n "$argn" ]; then
                 list_release $os

--- a/scripts/cvmfs/setup-nightlies.sh
+++ b/scripts/cvmfs/setup-nightlies.sh
@@ -8,6 +8,8 @@ function usage() {
     echo "       --help, -h   : print this help message"
     echo "       --list-releases [distribution] : list available releases for the specified distribution (almalinux, centos, ubuntu). By default (no OS is specified) it will list the releases for the detected distribution"
     echo "       --list-packages [distribution] : list available packages and their versions for the specified distribution (almalinux, centos, ubuntu). By default (no OS is specified) it will list the packages for the detected distribution"
+    echo "In addition, after sourcing, the command k4_local_repo can be used to add the current repository to the environment"
+    echo "It will delete all the existing paths containing the repository name and add some predefined paths to the environment"
 }
 
 function check_release() {

--- a/scripts/cvmfs/setup-releases.sh
+++ b/scripts/cvmfs/setup-releases.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-# This script sets up the Key4hep software stack from CVMFS for the nightlies
+# This script sets up the Key4hep software stack from CVMFS for the stable releases
 
 function usage() {
     echo "Usage: source /cvmfs/sw.hsf.org/key4hep/setup.sh [-r <release>] [--list-releases [distribution]] [--list-packages [distribution]]"
     echo "       -r <release> : setup a specific release, if not specified the latest release will be used (also used for --list-packages)"
-    echo "       -h           : print this help message"
+    echo "       --help, -h   : print this help message"
     echo "       --list-releases [distribution] : list available releases for the specified distribution (almalinux, centos, ubuntu). By default (no OS is specified) it will list the releases for the detected distribution"
     echo "       --list-packages [distribution] : list available packages and their versions for the specified distribution (almalinux, centos, ubuntu). By default (no OS is specified) it will list the packages for the detected distribution"
 }
@@ -99,6 +99,10 @@ for ((i=1; i<=$#; i++)); do
     eval arg=\$$i
     eval "argn=\${$((i+1))}"
     case $arg in
+        --help|-h)
+            usage
+            return 0
+            ;;
         --list-releases)
             if [ ! -n "$argn" ]; then
                 list_release $os

--- a/scripts/cvmfs/setup-releases.sh
+++ b/scripts/cvmfs/setup-releases.sh
@@ -8,6 +8,8 @@ function usage() {
     echo "       --help, -h   : print this help message"
     echo "       --list-releases [distribution] : list available releases for the specified distribution (almalinux, centos, ubuntu). By default (no OS is specified) it will list the releases for the detected distribution"
     echo "       --list-packages [distribution] : list available packages and their versions for the specified distribution (almalinux, centos, ubuntu). By default (no OS is specified) it will list the packages for the detected distribution"
+    echo "In addition, after sourcing, the command k4_local_repo can be used to add the current repository to the environment"
+    echo "It will delete all the existing paths containing the repository name and add some predefined paths to the environment"
 }
 
 function check_release() {


### PR DESCRIPTION
It seems we didn't have it when there was an usage function ready to be printed...,
now sourcing with `--help` or `-h` will print that.