### PR TITLE
k4fwcore: fix version ordering in when

### DIFF
--- a/packages/k4fwcore/package.py
+++ b/packages/k4fwcore/package.py
@@ -23,7 +23,7 @@ class K4fwcore(CMakePackage, Ilcsoftpackage):
     )
 
     depends_on("gaudi")
-    depends_on("gaudi +gaudialg", when="^gaudi@37: @:1.0pre19")
+    depends_on("gaudi +gaudialg", when="@:1.0pre19 ^gaudi@37:")
     depends_on("root")
     depends_on("podio")
     depends_on("podio@0.14.1", when="@1.0pre14:1.0pre15")


### PR DESCRIPTION
Fixes #591.

BEGINRELEASENOTES
- k4fwcore: correct version ordering in gaudi dependency `when` clause

ENDRELEASENOTES
