### PR TITLE
Revert "Remove pandorapfa and pandorasdk since they have been upstreamed"

### DIFF
--- a/packages/pandorapfa/package.py
+++ b/packages/pandorapfa/package.py
@@ -1,0 +1,68 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class Pandorapfa(Package):
+    """Metadata package to bring together and build multiple Pandora libraries.
+    NOTE: this recipe is not used to install  other pandora packages, for which
+    separate recipes exist. It only installs the cmakemodules directory."""
+
+    url = "https://github.com/PandoraPFA/PandoraPFA/archive/v03-14-00.tar.gz"
+    homepage = "https://github.com/PandoraPFA/PandoraPFA"
+    git = "https://github.com/PandoraPFA/PandoraPFA.git"
+
+    tags = ["hep"]
+
+    maintainers = ["vvolkl"]
+
+    version("master", branch="master")
+    version(
+        "4.8.1",
+        sha256="3b9e224196f09f3ce59062e73e1d05d4e8821d8163025263eee4448f7529f780",
+    )
+    version(
+        "4.4.1",
+        sha256="98c628b5063695fa73649136ded0aaa8e40cb34d06000096117606d926599f3b",
+    )
+    version(
+        "4.3.1",
+        sha256="2f4757a6ed2e10d3effc300b330f67ba13c499dbf21ba720b29b50527332fcdb",
+    )
+    version(
+        "4.3.0",
+        sha256="a794022c33b3a5afc1272740ac385e0c4ab96a112733012e7dfcbe80b5a3b445",
+    )
+    version(
+        "4.2.1",
+        sha256="1d262417748d18e00466ae3f1714ab0d7452e903bd1430773a72c652cf4666e4",
+    )
+    version(
+        "4.2.0",
+        sha256="5c1030db6047b2d6cef6b534a98f5293e0f97f8e35e92f254f2a61b4a20f5cee",
+    )
+    version(
+        "4.0.0",
+        sha256="80fdb60ac53ebada9d6ed2c6d0cefe79174586ce82e2e3bee7eefb4dbacbfba3",
+    )
+
+    patch("path.patch")
+
+    def install(self, a, b):
+        install_tree("cmakemodules", self.prefix.cmakemodules)
+
+    def url_for_version(self, version):
+        # contrary to ilcsoftpackages, here the patch version is kept when 0
+        base_url = self.url[: self.url.rfind("/")]
+        major = str(version[0]).zfill(2)
+        minor = str(version[1]).zfill(2)
+        patch = str(version[2]).zfill(2)
+        url = base_url + "/v%s-%s-%s.tar.gz" % (major, minor, patch)
+        return url
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.set("PANDORAPFA", self.prefix)
+
+    def setup_run_environment(self, env):
+        env.set("PANDORAPFA", self.prefix)

--- a/packages/pandorapfa/path.patch
+++ b/packages/pandorapfa/path.patch
@@ -1,0 +1,14 @@
+diff --git a/cmakemodules/MacroPandoraGeneratePackageConfigFiles.cmake b/cmakemodules/MacroPandoraGeneratePackageConfigFiles.cmake
+index 21adbfb..5e0354f 100644
+--- a/cmakemodules/MacroPandoraGeneratePackageConfigFiles.cmake
++++ b/cmakemodules/MacroPandoraGeneratePackageConfigFiles.cmake
+@@ -3,7 +3,7 @@
+ # helper macro for generating project configuration file
+ MACRO( PANDORA_GENERATE_PACKAGE_CONFIGURATION_FILES )
+ 
+-    FIND_PATH ( PANDORA_CMAKE_MODULES_PATH "MacroCheckPackageVersion.cmake" ${CMAKE_MODULE_PATH} )
++    SET ( PANDORA_CMAKE_MODULES_PATH  ${CMAKE_INSTALL_PREFIX}/cmakemodules/ )
+ 
+     FOREACH( arg ${ARGN} )
+         IF( ${arg} MATCHES "Config.cmake" )
+

--- a/packages/pandorasdk/package.py
+++ b/packages/pandorasdk/package.py
@@ -1,0 +1,51 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class Pandorasdk(CMakePackage):
+    """Metadata package to bring together and build multiple Pandora libraries.
+    NOTE: for proper version control with spack, this should be broken up and
+    the subpackages installed individually."""
+
+    url = "https://github.com/PandoraPFA/PandoraSDK/archive/v03-04-00.tar.gz"
+    homepage = "https://github.com/PandoraPFA/PandoraSDK"
+    git = "https://github.com/PandoraPFA/PandoraSDK.git"
+
+    tags = ["hep"]
+
+    maintainers = ["vvolkl"]
+
+    version("master", branch="master")
+    version(
+        "3.4.1",
+        sha256="9607bf52a9d79d88d28c45d4f3336e066338b36ab81b4d2d125226f4ad3a7aaf",
+    )
+    version(
+        "3.4.0",
+        sha256="1e30db056d4a43f8659fccdda00270af14593425d933f91e91d5c97f1e124c6b",
+    )
+
+    patch("path.patch")
+    patch("path2.patch")
+
+    depends_on("pandorapfa")
+
+    def cmake_args(self):
+        args = [
+            "-DLC_PANDORA_CONTENT=ON",
+            "-DLAR_PANDORA_CONTENT=ON",
+            "-DCMAKE_MODULE_PATH=%s" % self.spec["pandorapfa"].prefix.cmakemodules,
+            "-DCMAKE_CXX_FLAGS=-std=c++17",
+        ]
+        return args
+
+    def url_for_version(self, version):
+        # contrary to ilcsoftpackages, here the patch version is kept when 0
+        base_url = self.url[: self.url.rfind("/")]
+        major = str(version[0]).zfill(2)
+        minor = str(version[1]).zfill(2)
+        patch = str(version[2]).zfill(2)
+        url = base_url + "/v%s-%s-%s.tar.gz" % (major, minor, patch)
+        return url

--- a/packages/pandorasdk/path.patch
+++ b/packages/pandorasdk/path.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/PandoraSDKConfigVersion.cmake.in b/cmake/PandoraSDKConfigVersion.cmake.in
+index 44d646c..b438223 100644
+--- a/cmake/PandoraSDKConfigVersion.cmake.in
++++ b/cmake/PandoraSDKConfigVersion.cmake.in
+@@ -10,6 +10,6 @@ SET( ${PACKAGE_FIND_NAME}_VERSION_MINOR @PandoraSDK_VERSION_MINOR@ )
+ SET( ${PACKAGE_FIND_NAME}_VERSION_PATCH @PandoraSDK_VERSION_PATCH@ )
+
+
+-INCLUDE( "@PANDORA_CMAKE_MODULES_PATH@/MacroCheckPackageVersion.cmake" )
++INCLUDE( "MacroCheckPackageVersion" )
+ CHECK_PACKAGE_VERSION( ${PACKAGE_FIND_NAME} @PandoraSDK_VERSION@ )
+
+

--- a/packages/pandorasdk/path2.patch
+++ b/packages/pandorasdk/path2.patch
@@ -1,0 +1,14 @@
+diff --git a/cmake/PandoraSDKConfig.cmake.in b/cmake/PandoraSDKConfig.cmake.in
+index 2535058..263996c 100644
+--- a/cmake/PandoraSDKConfig.cmake.in
++++ b/cmake/PandoraSDKConfig.cmake.in
+@@ -42,7 +42,7 @@ FIND_PATH( PandoraSDK_INCLUDE_DIRS
+
+
+ # ---------- libraries --------------------------------------------------------
+-INCLUDE( "@PANDORA_CMAKE_MODULES_PATH@/MacroCheckPackageLibs.cmake" )
++INCLUDE( "MacroCheckPackageLibs" )
+
+ # only standard libraries should be passed as arguments to CHECK_PACKAGE_LIBS
+ # additional components are set by cmake in variable PKG_FIND_COMPONENTS
+


### PR DESCRIPTION
Reverts key4hep/key4hep-spack#593

Bringing this back since when building on top of an existing installation it wants the package in this repository as it was when installed originally.