### PR TITLE
Add FCC-config

### DIFF
--- a/packages/fcc-config/package.py
+++ b/packages/fcc-config/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Fccconfig(CMakePackage):
+    """"""
+
+    homepage = "https://github.com/HEP-FCC/FCC-config"
+    git = "https://github.com/HEP-FCC/FCC-config"
+
+    maintainers = ["jmcarcell"]
+
+    version("main", branch="main")
+
+    def cmake_args(self):
+        args = []
+        args.append("-DBUILD_TESTING=%s" % self.run_tests)
+        return args
+
+    def setup_run_environment(self, env):
+        env.prepend_path("FCCCONFIG", self.prefix)

--- a/packages/key4hep-stack/package.py
+++ b/packages/key4hep-stack/package.py
@@ -55,6 +55,7 @@ class Key4hepStack(BundlePackage, Key4hepPackage):
     depends_on("dd4hep")
     depends_on("delphes")
     depends_on("edm4hep")
+    depends_on("fcc-config")
     depends_on("geant4+qt")
     depends_on("guinea-pig")
     # depends_on('k4actstracking')

--- a/scripts/fetch_nightly_versions.py
+++ b/scripts/fetch_nightly_versions.py
@@ -117,6 +117,7 @@ if __name__ == "__main__":
         ("edm4hep", "key4hep/edm4hep"),
         ("fcalclusterer", "fcalsw/fcalclusterer"),
         ("fccanalyses", "hep-fcc/fccanalyses"),
+        ("fcc-config", "hep-fcc/fcc-config"),
         ("fccdetectors", "hep-fcc/fccdetectors"),
         ("fccsw", "hep-fcc/fccsw"),
         ("forwardtracking", "ilcsoft/forwardtracking"),


### PR DESCRIPTION
Needs https://github.com/HEP-FCC/FCC-config/pull/168 for it to be a CMake package. No dependencies since it doesn't have any tests. `FCCCONFIG` will point to the installation path similarly to how it's done for `CLDConfig`.