### PR TITLE
Add py-rich per user request

### DIFF
--- a/packages/key4hep-stack/package.py
+++ b/packages/key4hep-stack/package.py
@@ -118,6 +118,7 @@ class Key4hepStack(BundlePackage, Key4hepPackage):
     depends_on("py-jupytext@1.16:", when="+devtools")
     depends_on("py-matplotlib", when="+devtools")
     depends_on("py-nbconvert", when="+devtools")
+    depends_on("py-rich", when="+devtools")
     depends_on("py-onnxruntime", when="+devtools")
     depends_on("py-onnx", when="+devtools")
     depends_on("py-pandas", when="+devtools")


### PR DESCRIPTION
BEGINRELEASENOTES
- Add `py-rich` as dependency to `key4hep-stack` as it has been requested by users

ENDRELEASENOTES
