### PR TITLE
Use set instead of prepend_path to avoid a : at the end of the path

### DIFF
--- a/packages/cldconfig/package.py
+++ b/packages/cldconfig/package.py
@@ -36,4 +36,4 @@ class Cldconfig(CMakePackage):
         return args
 
     def setup_run_environment(self, env):
-        env.prepend_path("CLDCONFIG", self.prefix)
+        env.set("CLDCONFIG", self.prefix)

--- a/packages/fcc-config/package.py
+++ b/packages/fcc-config/package.py
@@ -22,4 +22,4 @@ class FccConfig(CMakePackage):
         return args
 
     def setup_run_environment(self, env):
-        env.prepend_path("FCCCONFIG", self.prefix)
+        env.set("FCCCONFIG", self.prefix)


### PR DESCRIPTION
for CLDConfig and FCC-config. See https://github.com/key4hep/key4hep-spack/issues/605.