### PR TITLE
marlinreco: add algorithm patch

### DIFF
--- a/packages/marlinreco/algorithm.patch
+++ b/packages/marlinreco/algorithm.patch
@@ -1,0 +1,12 @@
+diff --git a/CaloDigi/Realistic/src/RealisticCaloDigi.cc b/CaloDigi/Realistic/src/RealisticCaloDigi.cc
+index 6f37fce..bf51b16 100644
+--- a/CaloDigi/Realistic/src/RealisticCaloDigi.cc
++++ b/CaloDigi/Realistic/src/RealisticCaloDigi.cc
+@@ -17,6 +17,7 @@
+ #include <assert.h>
+ #include <cmath>
+ #include <set>
++#include <algorithm>
+ 
+ #include "CLHEP/Random/Random.h"
+ #include "CLHEP/Random/RandGauss.h"

--- a/packages/marlinreco/package.py
+++ b/packages/marlinreco/package.py
@@ -17,6 +17,10 @@ class Marlinreco(CMakePackage, Ilcsoftpackage):
 
     version("master", branch="master")
     version(
+        "1.36",
+        sha256="3f0c9839567a58b629b4cba40088b095a6660cbd104d157edf6dd21f81471694",
+    )
+    version(
         "1.35",
         sha256="009ea04769776424b203f08c9af75f544b8cd93f379537285e24e3470bb52be8",
     )

--- a/packages/marlinreco/package.py
+++ b/packages/marlinreco/package.py
@@ -41,7 +41,7 @@ class Marlinreco(CMakePackage, Ilcsoftpackage):
         sha256="0ea3bee03e2bec1924b5876675043b592a942bc8cf306eb7056eaf03ac1748f6",
     )
 
-    patch("algorithm.patch", when="@1.36")
+    patch("algorithm.patch", when="@:1.36")
 
     depends_on("ilcutil")
     depends_on("marlin")

--- a/packages/marlinreco/package.py
+++ b/packages/marlinreco/package.py
@@ -37,6 +37,8 @@ class Marlinreco(CMakePackage, Ilcsoftpackage):
         sha256="0ea3bee03e2bec1924b5876675043b592a942bc8cf306eb7056eaf03ac1748f6",
     )
 
+    patch("algorithm.patch", when="@1.36")
+
     depends_on("ilcutil")
     depends_on("marlin")
     depends_on("marlinutil")


### PR DESCRIPTION
BEGINRELEASENOTES
-  Version 1.36 has a missing include file necessary for gcc14

ENDRELEASENOTES
