### PR TITLE
Include spectrum for ROOT

### DIFF
--- a/environments/key4hep-common/packages.yaml
+++ b/environments/key4hep-common/packages.yaml
@@ -91,7 +91,7 @@ packages:
 
   # The version seems to be necessary, otherwise it defaults to an older version
   root:
-    require: '@6.32: +davix+fftw+gsl+math+minuit+mlp+opengl~postgres~pythia8+python+r+roofit+root7+rpath~shadow+sqlite+ssl+tbb+threads+tmva+tmva-cpu+unuran+vc+vdt+x+xml+xrootd cxxstd=20'
+    require: '@6.32: +davix+fftw+gsl+math+minuit+mlp+opengl~postgres~pythia8+python+r+roofit+root7+rpath~shadow+spectrum+sqlite+ssl+tbb+threads+tmva+tmva-cpu+unuran+vc+vdt+x+xml+xrootd cxxstd=20'
   py-tensorflow:
     require: ~cuda~nccl
   k4simdelphes:


### PR DESCRIPTION
Requested by ILD member for some backwards compatibility


BEGINRELEASENOTES
- Add the `+spectrum` variant for root

ENDRELEASENOTES
