### PR TITLE
Make MarlinKinfit available from ROOT

### DIFF
--- a/packages/marlinkinfit/package.py
+++ b/packages/marlinkinfit/package.py
@@ -43,3 +43,5 @@ class Marlinkinfit(CMakePackage, Ilcsoftpackage):
 
     def setup_run_environment(self, env):
         env.prepend_path("MARLIN_DLL", self.prefix.lib + "/libMarlinKinfit.so")
+        # Make it usable from ROOT
+        env.prepend_path("LD_LIBRARY_PATH", self.prefix.lib)


### PR DESCRIPTION
BEGINRELEASENOTES
- Add MarlinKinfit to the `LD_LIBRARY_PATH` to make it available from ROOT.

ENDRELEASENOTES

Fixes #635 
