### PR TITLE
fccsw: add include for py-onnxruntime

### DIFF
--- a/packages/fccsw/package.py
+++ b/packages/fccsw/package.py
@@ -28,6 +28,7 @@ class Fccsw(CMakePackage, Key4hepPackage):
     depends_on("k4geo")
     depends_on("fccanalyses")
     depends_on("root")
+    depends_on("py-onnxruntime")
     depends_on("py-six", type=("build", "run"))
 
     def cmake_args(self):


### PR DESCRIPTION
BEGINRELEASENOTES
-  add py-onnxruntime dep to fccsw to pick up include file needed by package
ENDRELEASENOTES
