### PR TITLE
update onnx to 1.16.1 for gcc14 compatibility

### DIFF
--- a/environments/key4hep-common/packages.yaml
+++ b/environments/key4hep-common/packages.yaml
@@ -124,8 +124,8 @@ packages:
   # And all should be consistent based on this table:
   # https://onnxruntime.ai/docs/reference/compatibility.html#onnx-opset-support
   onnx:
-    require: '@1.15.0'
+    require: '@1.16.1'
   py-onnx:
-    require: '@1.15.0'
+    require: '@1.16.1'
   py-onnxruntime:
     require: '@1.17.1'


### PR DESCRIPTION
BEGINRELEASENOTES
- update onnx to 1.16.1 for gcc14 compatibility
ENDRELEASENOTES
