### PR TITLE
Add the latest tag for k4MarlinWrapper with correct depenencies for k4EDM4hep2LCIOConv

### DIFF
--- a/packages/k4edm4hep2lcioconv/package.py
+++ b/packages/k4edm4hep2lcioconv/package.py
@@ -68,6 +68,7 @@ class K4edm4hep2lcioconv(CMakePackage, Key4hepPackage):
     depends_on("lcio@2.20.1:", when="@00-08:")
     depends_on("lcio@2.22:", when="@00-09:")
     depends_on("podio")
+    depends_on("podio@1:", when="@00-09:")
     depends_on("edm4hep@0.5:", when="@00-03")
     depends_on("edm4hep@0.8:", when="@00-04:")
     depends_on("edm4hep@0.10:", when="@00-05:")

--- a/packages/k4edm4hep2lcioconv/package.py
+++ b/packages/k4edm4hep2lcioconv/package.py
@@ -25,34 +25,42 @@ class K4edm4hep2lcioconv(CMakePackage, Key4hepPackage):
     version(
         "00-08-02",
         sha256="a0418b5c3c6ce77435bd942279420b0390099f417a7984227cf212710b079321",
+        deprecated=True,
     )
     version(
         "00-08-01",
         sha256="4518e39a0c87182d394f213074344ed29724005cd0481a2555a1fe48fdb98d2b",
+        deprecated=True,
     )
     version(
         "00-08",
         sha256="e3bfcb611b78d8e457d7f68e25d5aabe21b4b87928b0de0fc61a09734c7adb4c",
+        deprecated=True,
     )
     version(
         "00-07",
         sha256="269d14c390f987fb3fdb0d2e952febfb639415bef50e5e1c8992f23e0cd4a5a6",
+        deprecated=True,
     )
     version(
         "00-06",
         sha256="c220604577d309bc11a5a4c147f55640fedef90375d1232439343362607a3906",
+        deprecated=True,
     )
     version(
         "00-05",
         sha256="6d352bacff6a16f8d2643cdb108794d02889c38b119442c3c260f9a75cb63e7a",
+        deprecated=True,
     )
     version(
         "00-04",
         sha256="1b6db84f42a1d6e2e5a02cecbc01a0282081b7270a523f201fad4d39f78ca015",
+        deprecated=True,
     )
     version(
         "00-03",
         sha256="0b7fffbe1a07aae4b5b7523e855e944fe90f6e072dae9a460a07134025bf1cf8",
+        deprecated=True,
     )
 
     depends_on("lcio")

--- a/packages/k4edm4hep2lcioconv/package.py
+++ b/packages/k4edm4hep2lcioconv/package.py
@@ -58,10 +58,12 @@ class K4edm4hep2lcioconv(CMakePackage, Key4hepPackage):
     depends_on("lcio")
     depends_on("lcio@2.20:", when="@00-05:")
     depends_on("lcio@2.20.1:", when="@00-08:")
+    depends_on("lcio@2.22:", when="@00-09:")
     depends_on("podio")
     depends_on("edm4hep@0.5:", when="@00-03")
     depends_on("edm4hep@0.8:", when="@00-04:")
     depends_on("edm4hep@0.10:", when="@00-05:")
+    depends_on("edm4hep@0.99:", when="@00-09:")
 
     def cmake_args(self):
         args = [

--- a/packages/k4marlinwrapper/package.py
+++ b/packages/k4marlinwrapper/package.py
@@ -17,6 +17,9 @@ class K4marlinwrapper(CMakePackage, Ilcsoftpackage):
 
     version("main", branch="main")
     version(
+        "0.9", sha256="a0c01e6137cd5bb0794d79433831644dfd5108c763e436428117cd6f4a826ce2"
+    )
+    version(
         "0.8", sha256="0c624d5719cd055dfc27a9954cdf5e501e6478a2a8baac3bf80da7063e58e6ed"
     )
     version(
@@ -32,6 +35,7 @@ class K4marlinwrapper(CMakePackage, Ilcsoftpackage):
     depends_on("edm4hep")
     depends_on("edm4hep@0.10.1:")
     depends_on("k4edm4hep2lcioconv")
+    depends_on("k4edm4hep2lcioconv@0.9:", when="@0.9:")
     # for the doctest:
     depends_on("py-jupytext", type=("test"))
     depends_on("py-ipykernel", type=("test"))

--- a/packages/k4marlinwrapper/package.py
+++ b/packages/k4marlinwrapper/package.py
@@ -39,7 +39,7 @@ class K4marlinwrapper(CMakePackage, Ilcsoftpackage):
     depends_on("edm4hep")
     depends_on("edm4hep@0.10.1:")
     depends_on("k4edm4hep2lcioconv")
-    depends_on("k4edm4hep2lcioconv@0.9:", when="@0.9:")
+    depends_on("k4edm4hep2lcioconv@00-09:", when="@0.9:")
     # for the doctest:
     depends_on("py-jupytext", type=("test"))
     depends_on("py-ipykernel", type=("test"))

--- a/packages/k4marlinwrapper/package.py
+++ b/packages/k4marlinwrapper/package.py
@@ -20,10 +20,14 @@ class K4marlinwrapper(CMakePackage, Ilcsoftpackage):
         "0.9", sha256="a0c01e6137cd5bb0794d79433831644dfd5108c763e436428117cd6f4a826ce2"
     )
     version(
-        "0.8", sha256="0c624d5719cd055dfc27a9954cdf5e501e6478a2a8baac3bf80da7063e58e6ed"
+        "0.8",
+        sha256="0c624d5719cd055dfc27a9954cdf5e501e6478a2a8baac3bf80da7063e58e6ed",
+        deprecated=True,
     )
     version(
-        "0.7", sha256="aff49b9885d3c5e0804d5bcd3752ac77f3e3bbce6910fa9277252b907656914a"
+        "0.7",
+        sha256="aff49b9885d3c5e0804d5bcd3752ac77f3e3bbce6910fa9277252b907656914a",
+        deprecated=True,
     )
 
     depends_on("root")


### PR DESCRIPTION
BEGINRELEASENOTES
- Add the latest tag for k4MarlinWrapper with correct depenencies for k4EDM4hep2LCIOConv
- Mark any but the current version as deprecated

ENDRELEASENOTES
