### PR TITLE
Add tags and cherry picks for the next release

### DIFF
--- a/.cherry-pick
+++ b/.cherry-pick
@@ -57,3 +57,4 @@ git cherry-pick 248a7c0f4894222bfcd0bb76b13a984c92d4c938 -X theirs --no-commit
 # Versions for the release, in order DD4hep and podio&edm4hep
 git cherry-pick 43d1cdb0bd4780bff369dafa681a8a7939313784 -X theirs --no-commit
 git cherry-pick 5d9c534018593fdef5db1028c60026d26bf4d65b -X theirs --no-commit
+git cherry-pick be8112e1ff9dea12296bfafb341cc5953e72c415 -X theirs --no-commit

--- a/.cherry-pick
+++ b/.cherry-pick
@@ -54,4 +54,6 @@ curl -s https://patch-diff.githubusercontent.com/raw/spack/spack/pull/46465.diff
 git add .
 git cherry-pick 248a7c0f4894222bfcd0bb76b13a984c92d4c938 -X theirs --no-commit
 
-
+# Versions for the release, in order DD4hep and podio&edm4hep
+git cherry-pick 43d1cdb0bd4780bff369dafa681a8a7939313784 -X theirs --no-commit
+git cherry-pick 5d9c534018593fdef5db1028c60026d26bf4d65b -X theirs --no-commit

--- a/packages/fcc-config/package.py
+++ b/packages/fcc-config/package.py
@@ -10,11 +10,16 @@ class FccConfig(CMakePackage):
     """"""
 
     homepage = "https://github.com/HEP-FCC/FCC-config"
+    url = "https://github.com/HEP-FCC/FCC-config/archive/refs/tags/v0.1.0.tar.gz"
     git = "https://github.com/HEP-FCC/FCC-config"
 
     maintainers = ["jmcarcell"]
 
     version("main", branch="main")
+    version(
+        "0.1.0",
+        sha256="f609d88a1a6fbbdad50b8988012d80b8dad5c5fe31d6788761a7b06e1561736c",
+    )
 
     def cmake_args(self):
         args = []

--- a/packages/fccanalyses/package.py
+++ b/packages/fccanalyses/package.py
@@ -13,6 +13,10 @@ class Fccanalyses(CMakePackage, Key4hepPackage):
     version("master", branch="master")
 
     version(
+        "0.10.0",
+        sha256="a3cf897e1063a7e45fc3fb554c490af8fc2bafee338ae42aeaf455c851798e11",
+    )
+    version(
         "0.9.0",
         sha256="205332e02051039878c026abb7e1d9005fe9f89c1c9d27d575531f006a113570",
     )

--- a/packages/fccsw/package.py
+++ b/packages/fccsw/package.py
@@ -11,6 +11,12 @@ class Fccsw(CMakePackage, Key4hepPackage):
     maintainers = ["vvolkl"]
 
     version("master", branch="master")
+
+    version(
+        "1.0pre10",
+        sha256="7d7cd655a557b272e816b399c068fa5e6ee1c72491bb7e0dffa552557b949cbf",
+    )
+
     version("1.0pre09", tag="v1.0pre09")
     version("1.0pre08", tag="v1.0pre08")
     version("1.0pre07", tag="v1.0pre07")

--- a/packages/k4clue/package.py
+++ b/packages/k4clue/package.py
@@ -17,6 +17,11 @@ class K4clue(CMakePackage, Ilcsoftpackage):
     maintainers = ["jmcarcell"]
 
     version("main", branch="main")
+
+    version(
+        "1.0.6",
+        sha256="f9b88a1810dc1213671a3a0bbb581c00cb28c3a95afe0a171f9aa852d746263e",
+    )
     version(
         "1.0.5",
         sha256="1c848d72d1f74b057e37c00f6c4d120e5c3b2ba5720b766e5bb09bba8fbf508f",

--- a/packages/k4fwcore/package.py
+++ b/packages/k4fwcore/package.py
@@ -9,6 +9,12 @@ class K4fwcore(CMakePackage, Ilcsoftpackage):
     git = "https://github.com/key4hep/k4FWCore.git"
 
     version("main", branch="main")
+
+    version(
+        "1.1.0",
+        sha256="31b03daf5f839708113f3452c6626975aa8b070a7cbbb3576b29b86918df13d3",
+    )
+
     version("1.0pre19", tag="v01-00pre19")
     version("1.0pre18", tag="v01-00pre18")
     version("1.0pre17", tag="v01-00pre17")

--- a/packages/k4gen/package.py
+++ b/packages/k4gen/package.py
@@ -12,6 +12,10 @@ class K4gen(CMakePackage, Key4hepPackage):
 
     version("main", branch="main")
     version(
+        "0.1pre12",
+        sha256="1356f748c0be4d5a33f0e1b2b3f4fbd9f03e185f1f53df2d59b254f960e860af",
+    )
+    version(
         "0.1pre11",
         sha256="750900ee2da2a09a101843e9ea03cc0cbd04451f3dbe01336c4adece06097efc",
     )

--- a/packages/k4geo/package.py
+++ b/packages/k4geo/package.py
@@ -17,13 +17,15 @@ class K4geo(CMakePackage):
 
     version("main", branch="main")
     version(
+        "0.21",
+        sha256="11074495f861d944b741187e8e4dedb4e7f85124f304605f8f8c7dce69dda4fb",
+    )
+    version(
         "0.20",
-        url="https://github.com/key4hep/k4geo/archive/v00-20-00.tar.gz",
         sha256="40d5842faa4767cc1b8c19f9b710713ba6a128ecd94fb9682e3afe3145e20511",
     )
     version(
         "0.19",
-        url="https://github.com/key4hep/k4geo/archive/v00-19-00.tar.gz",
         sha256="6e8101e5991870484988f9fcb0299076a30f9b5f37e4e51141e50dfd30f32314",
     )
 

--- a/packages/k4projecttemplate/package.py
+++ b/packages/k4projecttemplate/package.py
@@ -1,5 +1,4 @@
 from spack.pkg.k4.key4hep_stack import Key4hepPackage
-from spack.pkg.k4.key4hep_stack import k4_setup_env_for_framework_tests
 
 
 class K4projecttemplate(CMakePackage, Key4hepPackage):
@@ -15,20 +14,16 @@ class K4projecttemplate(CMakePackage, Key4hepPackage):
 
     version("main", branch="main")
     version(
+        "0.5.0",
+        sha256="801ecc3319109c74ba62decd57473be8c65aea79991b7c4ac5e5a84209036f9a",
+    )
+    version(
         "0.4.1",
         sha256="02a6432e7661a16371bda87d4352cd92bc77168a7f28528353ade721e931984c",
     )
     version(
         "0.4.0",
         sha256="e1fb8992f85ba29918e1103d3472e4ca272a16b09819f7d1ed79e6d97c4445a4",
-    )
-    version(
-        "0.3.0",
-        sha256="c0adb1dc9c97bc1b5610727fdaa5e1466d003249a215806e39b605d86ed42537",
-    )
-    version(
-        "0.2.0",
-        sha256="213b86a6c1a7c83bcab8bb05e64a35d7f4d206f0c7962c1e51eeb0ee04989c54",
     )
 
     generator = "Ninja"
@@ -50,6 +45,3 @@ class K4projecttemplate(CMakePackage, Key4hepPackage):
     def setup_run_environment(self, env):
         env.prepend_path("PYTHONPATH", self.prefix.python)
         env.set("K4PROJECTTEMPLATE", self.prefix.share.k4ProjectTemplate)
-
-    # def setup_build_environment(self, env):
-    #     k4_setup_env_for_framework_tests(self.spec, env)

--- a/packages/k4reccalorimeter/package.py
+++ b/packages/k4reccalorimeter/package.py
@@ -12,6 +12,10 @@ class K4reccalorimeter(CMakePackage, Key4hepPackage):
 
     version("main", branch="main")
     version(
+        "0.1.0pre15",
+        sha256="8406e7ca3ff78a93ace7ca645f49bea979931b9f268e5d2aaad958886f9e7b55",
+    )
+    version(
         "0.1.0pre14",
         sha256="4e3480e02806a708fabcb4014f082e1de89cb4a2fb838994848bef6664ff5168",
     )

--- a/packages/k4reccalorimeter/package.py
+++ b/packages/k4reccalorimeter/package.py
@@ -11,6 +11,10 @@ class K4reccalorimeter(CMakePackage, Key4hepPackage):
     maintainers = ["vvolkl"]
 
     version("main", branch="main")
+    version(
+        "0.1.0pre14",
+        sha256="4e3480e02806a708fabcb4014f082e1de89cb4a2fb838994848bef6664ff5168",
+    )
     version("0.1.0pre13", tag="v0.1.0pre13")
     version("0.1.0pre12", tag="v0.1.0pre12")
     version("0.1.0pre11", tag="v0.1.0pre11")

--- a/packages/k4reco/package.py
+++ b/packages/k4reco/package.py
@@ -10,6 +10,11 @@ class K4reco(CMakePackage, Key4hepPackage):
 
     version("main", branch="main")
 
+    version(
+        "0.1.0",
+        sha256="93ee8a66aeb31ed501a356a145551f9836fb744e22b435c6577ea5274ece39c6",
+    )
+
     depends_on("dd4hep")
     depends_on("edm4hep")
     depends_on("gaudi")

--- a/packages/k4simgeant4/package.py
+++ b/packages/k4simgeant4/package.py
@@ -11,6 +11,7 @@ class K4simgeant4(CMakePackage, Key4hepPackage):
     maintainers = ["vvolkl"]
 
     version("main", branch="main")
+    version("0.1.0pre15", tag="v0.1.0pre15")
     version("0.1.0pre14", tag="v0.1.0pre14")
     version("0.1.0pre13", tag="v0.1.0pre13")
     version("0.1.0pre12", tag="v0.1.0pre12")


### PR DESCRIPTION
See https://github.com/key4hep/key4hep-spack/issues/647. Off the top of my head k4FWCore and k4geo are still missing.