### PR TITLE
Remove a patch for k4RecCalorimeter

### DIFF
--- a/packages/k4reccalorimeter/package.py
+++ b/packages/k4reccalorimeter/package.py
@@ -41,12 +41,6 @@ class K4reccalorimeter(CMakePackage, Key4hepPackage):
     depends_on("py-onnxruntime")
     depends_on("root")
 
-    patch(
-        "https://patch-diff.githubusercontent.com/raw/HEP-FCC/k4RecCalorimeter/pull/81.patch?full_index=1",
-        sha256="a46d2fa00230d92e23788bf41870748c64c0a4ef2973bec3b26d1cf6dfc9c2db",
-        when="@:0.1.0pre13 ^py-onnxruntime@1.17.1:",
-    )
-
     def cmake_args(self):
         args = []
         args.append(


### PR DESCRIPTION
that doesn't seem to apply. I think what happened is the version that the patch is patching never made it to a release and I was using it for the nightlies. Supersedes https://github.com/key4hep/key4hep-spack/pull/663