### PR TITLE
Require newer version for py-setuptools explicitly to ensure py-onnx builds

### DIFF
--- a/environments/key4hep-common/packages.yaml
+++ b/environments/key4hep-common/packages.yaml
@@ -126,3 +126,6 @@ packages:
     require: '@1.15.0'
   py-onnxruntime:
     require: '@1.17.1'
+  # Otherwise py-onnx will no longer build
+  py-setuptools:
+    require: "@69:"


### PR DESCRIPTION
Without this I run int a weird build error for py-onnx (see below). It's also not entirely clear to me why it picks up a lower version of py-setuptools, because purely from the dependency graph it should actually get `py-setuptools@69`

```console
==> py-onnx: Executing phase: 'install'
==> Error: ProcessError: Command exited with status 1:
    '/home/madlener/work/.spack/spackages/skylake-ubuntu24.04-gcc13.2.0/python-venv/1.0-ttdjab/bin/python3' '-m' 'pip' '-vvv' '--no-input' '--no-cache-dir' '--disable-pip-version-check' 'install' '--no-deps' '--ignore-installed' '--no-build-isolation' '--no-warn-script-location' '--no-index' '--prefix=/home/madlener/work/.spack/spackages/skylake-ubuntu24.04-gcc13.2.0/py-onnx/1.15.0-uhi5kz' '.'

2 errors found in build log:
     12      Processing /tmp/madlener/spack-stage/spack-stage-py-onnx-1.15.0-uhi5kzip3kuzggoeg2zjph6wvy4hhyhy/spack-src
     13        Added file:///tmp/madlener/spack-stage/spack-stage-py-onnx-1.15.0-uhi5kzip3kuzggoeg2zjph6wvy4hhyhy/spack-src to build tracker '/tmp/pip-build-tracker-rvymwchc'
     14        Created temporary directory: /tmp/pip-modern-metadata-2h8qti79
     15        Preparing metadata (pyproject.toml): started
     16        Running command Preparing metadata (pyproject.toml)
     17        fatal: not a git repository (or any of the parent directories): .git
  >> 18      /home/madlener/work/.spack/spackages/skylake-ubuntu24.04-gcc13.2.0/py-setuptools/62.6.0-r6oim4/lib/python3.11/site-packages/setuptools/config/pyprojecttoml.py:104: _BetaConfigu
             ration: Support for `[tool.setuptools]` in `pyproject.toml` is still *beta*.
     19          warnings.warn(msg, _BetaConfiguration)
     20        running dist_info
     21        creating /tmp/pip-modern-metadata-2h8qti79/onnx.egg-info
     22        writing /tmp/pip-modern-metadata-2h8qti79/onnx.egg-info/PKG-INFO
     23        writing dependency_links to /tmp/pip-modern-metadata-2h8qti79/onnx.egg-info/dependency_links.txt
     24        writing entry points to /tmp/pip-modern-metadata-2h8qti79/onnx.egg-info/entry_points.txt

     ...

     2865    Building wheels for collected packages: onnx
     2866      Created temporary directory: /tmp/pip-wheel-7sa9hgv_
     2867      Destination directory: /tmp/pip-wheel-7sa9hgv_
     2868      Building wheel for onnx (pyproject.toml): started
     2869      Running command Building wheel for onnx (pyproject.toml)
     2870      fatal: not a git repository (or any of the parent directories): .git
  >> 2871    /home/madlener/work/.spack/spackages/skylake-ubuntu24.04-gcc13.2.0/py-setuptools/62.6.0-r6oim4/lib/python3.11/site-packages/setuptools/config/pyprojecttoml.py:104: _BetaConfigu
             ration: Support for `[tool.setuptools]` in `pyproject.toml` is still *beta*.
     2872        warnings.warn(msg, _BetaConfiguration)
     2873      running bdist_wheel
     2874      running build
     2875      running build_py
     2876      Traceback (most recent call last):
     2877        File "/home/madlener/work/.spack/spackages/skylake-ubuntu24.04-gcc13.2.0/py-pip/23.1.2-2rarbw/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_proce
             ss.py", line 353, in <module>

See build log for details:
  /tmp/madlener/spack-stage/spack-stage-py-onnx-1.15.0-uhi5kzip3kuzggoeg2zjph6wvy4hhyhy/spack-build-out.txt
```


BEGINRELEASENOTES
- Require a new enough version of `py-setuptools` to build `py-onnx`

ENDRELEASENOTES
