### PR TITLE
Use the commit that actually landed in upstream spack

### DIFF
--- a/.cherry-pick
+++ b/.cherry-pick
@@ -53,7 +53,7 @@ curl -s https://patch-diff.githubusercontent.com/raw/spack/spack/pull/46465.diff
 
 # py-onnx: add a patch for the standard, remove after 1.15.0
 git add .
-git cherry-pick 248a7c0f4894222bfcd0bb76b13a984c92d4c938 -X theirs --no-commit
+git cherry-pick bbd205543b09139f2f57f21099eb366c9f183d76 -X theirs --no-commit
 
 # py-cython: add version 3.0.11, remove when https://github.com/spack/spack/pull/46772 is merged
 git cherry-pick 072d308c0b4b53c0d0528ee3a7e59de110133968 -X theirs --no-commit


### PR DESCRIPTION
BEGINRELEASENOTES
- Use the spack that landed in upstream spack for `py-onnx`. This has the better matching criteria for when it should be applied.

ENDRELEASENOTES

After just spending about half an hour wondering why the patch that I wanted seems to not have been applied.