### PR TITLE
Enable PandoraMonitoring and add variants for the packages that use it

### DIFF
--- a/environments/key4hep-common/packages.yaml
+++ b/environments/key4hep-common/packages.yaml
@@ -12,6 +12,8 @@ packages:
     buildable: true
   curl:
     require: +gssapi
+  ddmarlinpandora:
+    require: +monitoring
   dd4hep:
     require: +edm4hep+lcio+xercesc+hepmc3
   gaudi:
@@ -26,8 +28,12 @@ packages:
   hepmc3:
     require: +python+rootio
   # https://github.com/key4hep/key4hep-spack/issues/517
+  larcontent:
+    require: +monitoring
   lccd:
     require: +conddbmysql
+  lccontent:
+    require: +monitoring
   llvm:
     variants: ~flang~lldb~lld~lua~mlir~internal_unwind~polly~libomptarget~libomptarget_debug~gold~split_dwarf~llvm_dylib~link_llvm_dylib~omp_tsan~omp_as_runtime~code_signing~python~version_suffix~shlib_symbol_version~z3~zstd compiler-rt="none" libcxx="none" targets="x86"
   marlin:

--- a/packages/ddmarlinpandora/package.py
+++ b/packages/ddmarlinpandora/package.py
@@ -48,7 +48,7 @@ class Ddmarlinpandora(CMakePackage, Ilcsoftpackage):
 
     def setup_build_environment(self, env):
         if "+monitoring" in self.spec:
-            env.set('PANDORA_MONITORING', 'ON')
+            env.set("PANDORA_MONITORING", "ON")
 
     def setup_run_environment(self, env):
         env.prepend_path("MARLIN_DLL", self.prefix.lib + "/libDDMarlinPandora.so")

--- a/packages/ddmarlinpandora/package.py
+++ b/packages/ddmarlinpandora/package.py
@@ -42,6 +42,13 @@ class Ddmarlinpandora(CMakePackage, Ilcsoftpackage):
     depends_on("larcontent")
     depends_on("dd4hep")
     depends_on("marlintrk")
+    depends_on("pandoramonitoring", when="+monitoring")
+
+    variant("monitoring", default=False, description="Enable Pandora Monitoring")
+
+    def setup_build_environment(self, env):
+        if "+monitoring" in self.spec:
+            env.set('PANDORA_MONITORING', 'ON')
 
     def setup_run_environment(self, env):
         env.prepend_path("MARLIN_DLL", self.prefix.lib + "/libDDMarlinPandora.so")

--- a/packages/ilcsoft/package.py
+++ b/packages/ilcsoft/package.py
@@ -79,6 +79,7 @@ class Ilcsoft(BundlePackage, Key4hepPackage):
     depends_on("marlinmlflavortagging")
     depends_on("overlay")
     depends_on("pandoraanalysis")
+    depends_on("pandoramonitoring")
     depends_on("pandorapfa")
     depends_on("physsim")
     depends_on("raida")

--- a/packages/larcontent/package.py
+++ b/packages/larcontent/package.py
@@ -39,10 +39,18 @@ class Larcontent(CMakePackage):
     depends_on("pandorasdk")
     depends_on("eigen")
 
+    depends_on("pandoramonitoring", when="+monitoring")
+
+    variant("monitoring", default=False, description="Enable Pandora Monitoring")
+
+    def setup_build_environment(self, env):
+        if "+monitoring" in self.spec:
+            env.set('PANDORA_MONITORING', 'ON')
+
     def cmake_args(self):
         args = [
             "-DCMAKE_MODULE_PATH=%s" % self.spec["pandorapfa"].prefix.cmakemodules,
-            "-DCMAKE_CXX_FLAGS=-std=c++17 -Wno-error",
+            "-DCMAKE_CXX_FLAGS=-std=c++20 -Wno-error",
         ]
         return args
 

--- a/packages/larcontent/package.py
+++ b/packages/larcontent/package.py
@@ -45,7 +45,7 @@ class Larcontent(CMakePackage):
 
     def setup_build_environment(self, env):
         if "+monitoring" in self.spec:
-            env.set('PANDORA_MONITORING', 'ON')
+            env.set("PANDORA_MONITORING", "ON")
 
     def cmake_args(self):
         args = [

--- a/packages/lccontent/package.py
+++ b/packages/lccontent/package.py
@@ -40,7 +40,7 @@ class Lccontent(CMakePackage):
 
     def setup_build_environment(self, env):
         if "+monitoring" in self.spec:
-            env.set('PANDORA_MONITORING', 'ON')
+            env.set("PANDORA_MONITORING", "ON")
 
     def cmake_args(self):
         args = [

--- a/packages/lccontent/package.py
+++ b/packages/lccontent/package.py
@@ -34,9 +34,17 @@ class Lccontent(CMakePackage):
     depends_on("pandorapfa")
     depends_on("pandorasdk")
 
+    depends_on("pandoramonitoring", when="+monitoring")
+
+    variant("monitoring", default=False, description="Enable Pandora Monitoring")
+
+    def setup_build_environment(self, env):
+        if "+monitoring" in self.spec:
+            env.set('PANDORA_MONITORING', 'ON')
+
     def cmake_args(self):
         args = [
-            "-DCMAKE_CXX_STANDARD=17",
+            "-DCMAKE_CXX_STANDARD=20",
             "-DCMAKE_MODULE_PATH=%s" % self.spec["pandorapfa"].prefix.cmakemodules,
             "-DCMAKE_CXX_FLAGS=-Wno-error",
         ]


### PR DESCRIPTION
See #679

Remaining questions:
- Do we want PandoraMonitoring in the nightlies? No one seems to be working on it
- PandoraPFA also uses PandoraMonitoring but instead of finding it like other packages it builds it, see https://github.com/PandoraPFA/PandoraPFA/blob/5f673558a76fd2a32da529870bc247a4fa85aa81/CMakeLists.txt#L44 and https://github.com/PandoraPFA/PandoraPFA/blob/5f673558a76fd2a32da529870bc247a4fa85aa81/CMakeLists.txt#L114 so it would mean there is another version in the stack. I haven't added it yet.