### PR TITLE
Fix setting the PANDORA_MONITORING cmake variable

### DIFF
--- a/packages/ddmarlinpandora/package.py
+++ b/packages/ddmarlinpandora/package.py
@@ -46,13 +46,11 @@ class Ddmarlinpandora(CMakePackage, Ilcsoftpackage):
 
     variant("monitoring", default=False, description="Enable Pandora Monitoring")
 
-    def setup_build_environment(self, env):
-        if "+monitoring" in self.spec:
-            env.set("PANDORA_MONITORING", "ON")
-
     def setup_run_environment(self, env):
         env.prepend_path("MARLIN_DLL", self.prefix.lib + "/libDDMarlinPandora.so")
 
     def cmake_args(self):
-        # C++ Standard
-        return [f"-DCMAKE_CXX_STANDARD={self.spec['root'].variants['cxxstd'].value}"]
+        return [
+            f"-DCMAKE_CXX_STANDARD={self.spec['root'].variants['cxxstd'].value}",
+            self.define_from_variant("PANDORA_MONITORING", "monitoring"),
+        ]

--- a/packages/larcontent/package.py
+++ b/packages/larcontent/package.py
@@ -43,14 +43,11 @@ class Larcontent(CMakePackage):
 
     variant("monitoring", default=False, description="Enable Pandora Monitoring")
 
-    def setup_build_environment(self, env):
-        if "+monitoring" in self.spec:
-            env.set("PANDORA_MONITORING", "ON")
-
     def cmake_args(self):
         args = [
             "-DCMAKE_MODULE_PATH=%s" % self.spec["pandorapfa"].prefix.cmakemodules,
-            "-DCMAKE_CXX_FLAGS=-std=c++20 -Wno-error",
+            "-DCMAKE_CXX_FLAGS=-std=c++17 -Wno-error",
+            self.define_from_variant("PANDORA_MONITORING", "monitoring"),
         ]
         return args
 

--- a/packages/lccontent/package.py
+++ b/packages/lccontent/package.py
@@ -38,15 +38,12 @@ class Lccontent(CMakePackage):
 
     variant("monitoring", default=False, description="Enable Pandora Monitoring")
 
-    def setup_build_environment(self, env):
-        if "+monitoring" in self.spec:
-            env.set("PANDORA_MONITORING", "ON")
-
     def cmake_args(self):
         args = [
             "-DCMAKE_CXX_STANDARD=20",
             "-DCMAKE_MODULE_PATH=%s" % self.spec["pandorapfa"].prefix.cmakemodules,
             "-DCMAKE_CXX_FLAGS=-Wno-error",
+            self.define_from_variant("PANDORA_MONITORING", "monitoring"),
         ]
         return args
 


### PR DESCRIPTION
needed after #681. PandoraMonitoring installed fine but it is not being used yet.