### PR TITLE
fix: ensure from spack.package import *

### DIFF
--- a/packages/aidatt/package.py
+++ b/packages/aidatt/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 

--- a/packages/babayaga/package.py
+++ b/packages/babayaga/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
+
 import os
 
 

--- a/packages/bhlumi/package.py
+++ b/packages/bhlumi/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
+
 import os
 
 

--- a/packages/ced/package.py
+++ b/packages/ced/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 

--- a/packages/cedviewer/package.py
+++ b/packages/cedviewer/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 

--- a/packages/cepcsw/package.py
+++ b/packages/cepcsw/package.py
@@ -1,3 +1,4 @@
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Key4hepPackage
 
 

--- a/packages/cldconfig/package.py
+++ b/packages/cldconfig/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
+from spack.package import *
 
 
 class Cldconfig(CMakePackage):

--- a/packages/clicperformance/package.py
+++ b/packages/clicperformance/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 

--- a/packages/clupatra/package.py
+++ b/packages/clupatra/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 

--- a/packages/conddbmysql/package.py
+++ b/packages/conddbmysql/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Key4hepPackage
 
 

--- a/packages/conformaltracking/package.py
+++ b/packages/conformaltracking/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 

--- a/packages/ddfastshowerml/package.py
+++ b/packages/ddfastshowerml/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Key4hepPackage
 
 

--- a/packages/ddkaltest/package.py
+++ b/packages/ddkaltest/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 

--- a/packages/ddmarlinpandora/package.py
+++ b/packages/ddmarlinpandora/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 

--- a/packages/dual-readout/package.py
+++ b/packages/dual-readout/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Key4hepPackage
 
 

--- a/packages/emela/package.py
+++ b/packages/emela/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
+
 
 class Emela(CMakePackage):
     """Library that implements the evolution in pure QED of the unpolarised electron parton distribution functions (PDFs) up to next-to-leading logarithmic (NLL) approximation"""

--- a/packages/fcalclusterer/package.py
+++ b/packages/fcalclusterer/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 from spack.pkg.k4.key4hep_stack import k4_setup_env_for_framework_tests
 

--- a/packages/fcc-config/package.py
+++ b/packages/fcc-config/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
+from spack.package import *
 
 
 class FccConfig(CMakePackage):

--- a/packages/fccanalyses/package.py
+++ b/packages/fccanalyses/package.py
@@ -1,3 +1,4 @@
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Key4hepPackage
 
 

--- a/packages/fccdetectors/package.py
+++ b/packages/fccdetectors/package.py
@@ -1,3 +1,4 @@
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Key4hepPackage
 
 

--- a/packages/fccsw/package.py
+++ b/packages/fccsw/package.py
@@ -1,3 +1,4 @@
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Key4hepPackage
 
 

--- a/packages/forwardtracking/package.py
+++ b/packages/forwardtracking/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 

--- a/packages/garlic/package.py
+++ b/packages/garlic/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 

--- a/packages/gear/package.py
+++ b/packages/gear/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 

--- a/packages/generalbrokenlines/package.py
+++ b/packages/generalbrokenlines/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
+
 
 class Generalbrokenlines(CMakePackage):
     """Track refitting with broken lines in 3D."""

--- a/packages/guinea-pig/package.py
+++ b/packages/guinea-pig/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
+
 
 class GuineaPig(CMakePackage):
     """Generator of Unwanted Interactions for Numerical Experiment

--- a/packages/ilcsoft/package.py
+++ b/packages/ilcsoft/package.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Key4hepPackage
 from spack.pkg.k4.key4hep_stack import install_setup_script
 

--- a/packages/ilcutil/package.py
+++ b/packages/ilcutil/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 

--- a/packages/ildperformance/package.py
+++ b/packages/ildperformance/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 

--- a/packages/k4actstracking/package.py
+++ b/packages/k4actstracking/package.py
@@ -1,3 +1,4 @@
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Key4hepPackage
 
 

--- a/packages/k4clue/package.py
+++ b/packages/k4clue/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 

--- a/packages/k4edm4hep2lcioconv/package.py
+++ b/packages/k4edm4hep2lcioconv/package.py
@@ -3,8 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
-
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Key4hepPackage
 
 

--- a/packages/k4fwcore/package.py
+++ b/packages/k4fwcore/package.py
@@ -1,3 +1,4 @@
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 

--- a/packages/k4gaudipandora/package.py
+++ b/packages/k4gaudipandora/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Key4hepPackage
 
 

--- a/packages/k4gen/package.py
+++ b/packages/k4gen/package.py
@@ -1,3 +1,4 @@
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Key4hepPackage
 
 

--- a/packages/k4generatorsconfig/package.py
+++ b/packages/k4generatorsconfig/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
+
 
 class K4generatorsconfig(CMakePackage):
     """A python based module for the automatic generation of inputfiles for Monte-Carlo(MC) generators."""

--- a/packages/k4geo/package.py
+++ b/packages/k4geo/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
+
 
 class K4geo(CMakePackage):
     """DD4hep geometry models for future colliders."""

--- a/packages/k4marlinwrapper/package.py
+++ b/packages/k4marlinwrapper/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 

--- a/packages/k4pandora/package.py
+++ b/packages/k4pandora/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Key4hepPackage
 
 

--- a/packages/k4projecttemplate/package.py
+++ b/packages/k4projecttemplate/package.py
@@ -1,3 +1,4 @@
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Key4hepPackage
 
 

--- a/packages/k4reccalorimeter/package.py
+++ b/packages/k4reccalorimeter/package.py
@@ -1,3 +1,4 @@
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Key4hepPackage
 
 

--- a/packages/k4reco/package.py
+++ b/packages/k4reco/package.py
@@ -1,3 +1,4 @@
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Key4hepPackage
 
 

--- a/packages/k4rectracker/package.py
+++ b/packages/k4rectracker/package.py
@@ -1,3 +1,4 @@
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Key4hepPackage
 
 

--- a/packages/k4simdelphes/package.py
+++ b/packages/k4simdelphes/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 

--- a/packages/k4simgeant4/package.py
+++ b/packages/k4simgeant4/package.py
@@ -1,3 +1,4 @@
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Key4hepPackage
 
 

--- a/packages/kaldet/package.py
+++ b/packages/kaldet/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 

--- a/packages/kaltest/package.py
+++ b/packages/kaltest/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 

--- a/packages/key4hep-stack/common.py
+++ b/packages/key4hep-stack/common.py
@@ -2,7 +2,7 @@
 Common methods for use in Key4hep recipes
 """
 
-from spack import *
+from spack.package import *
 from spack.directives import *
 from spack.user_environment import *
 

--- a/packages/kitrack/package.py
+++ b/packages/kitrack/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 

--- a/packages/kitrackmarlin/package.py
+++ b/packages/kitrackmarlin/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 

--- a/packages/kkmcee/package.py
+++ b/packages/kkmcee/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
+
 import os
 import glob
 

--- a/packages/larcontent/package.py
+++ b/packages/larcontent/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
+
 
 class Larcontent(CMakePackage):
     """Pandora algorithms and tools for LAr TPC event reconstruction"""

--- a/packages/lccd/package.py
+++ b/packages/lccd/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 

--- a/packages/lccontent/package.py
+++ b/packages/lccontent/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
+
 
 class Lccontent(CMakePackage):
     """Pandora algorithms and tools for Linear Collider event reconstruction."""

--- a/packages/lcfiplus/package.py
+++ b/packages/lcfiplus/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 

--- a/packages/lcfivertex/package.py
+++ b/packages/lcfivertex/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 

--- a/packages/lctuple/package.py
+++ b/packages/lctuple/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 

--- a/packages/lich/package.py
+++ b/packages/lich/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 

--- a/packages/marlin/package.py
+++ b/packages/marlin/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 

--- a/packages/marlindd4hep/package.py
+++ b/packages/marlindd4hep/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 

--- a/packages/marlinfastjet/package.py
+++ b/packages/marlinfastjet/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 

--- a/packages/marlinkinfit/package.py
+++ b/packages/marlinkinfit/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 

--- a/packages/marlinkinfitprocessors/package.py
+++ b/packages/marlinkinfitprocessors/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 

--- a/packages/marlinmlflavortagging/package.py
+++ b/packages/marlinmlflavortagging/package.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python3
-
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Key4hepPackage
 
 

--- a/packages/marlinreco/package.py
+++ b/packages/marlinreco/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 

--- a/packages/marlintrk/package.py
+++ b/packages/marlintrk/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 

--- a/packages/marlintrkprocessors/package.py
+++ b/packages/marlintrkprocessors/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 

--- a/packages/marlinutil/package.py
+++ b/packages/marlinutil/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 

--- a/packages/overlay/package.py
+++ b/packages/overlay/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 

--- a/packages/pandoraanalysis/package.py
+++ b/packages/pandoraanalysis/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 

--- a/packages/physsim/package.py
+++ b/packages/physsim/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 

--- a/packages/py-pybdsim/package.py
+++ b/packages/py-pybdsim/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
+
 
 class PyPybdsim(PythonPackage):
     """Utilities for preparing and analysing BDSIM input and output as well as controlling BDSIM"""

--- a/packages/py-pyg4ometry/package.py
+++ b/packages/py-pyg4ometry/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
+
 
 class PyPyg4ometry(PythonPackage):
     """Geometry package for high energy physics (Geant4, Fluka)"""

--- a/packages/py-pyhepmc/package.py
+++ b/packages/py-pyhepmc/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
+
 
 class PyPyhepmc(PythonPackage):
     """Python bindings for HepMC3"""

--- a/packages/py-pymadx/package.py
+++ b/packages/py-pymadx/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
+
 
 class PyPymadx(PythonPackage):
     """Utilities for processing and analysing MADX output"""

--- a/packages/py-pytransport/package.py
+++ b/packages/py-pytransport/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
+
 
 class PyPytransport(PythonPackage):
     """A Python based converter for TRANSPORT files to BDSIM readable gmad files"""

--- a/packages/raida/package.py
+++ b/packages/raida/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
 from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 
 


### PR DESCRIPTION
BEGINRELEASENOTES
- ensure all packages have `from spack.package import *`

ENDRELEASENOTES

This PR ensures that all packages have a `from spack.package import *` line since it is not injected by spack anymore. Ref: spack/spack#47947