### PR TITLE
fix: ilc_url_for_version support for v00-04-pre patch levels

### DIFF
--- a/packages/key4hep-stack/common.py
+++ b/packages/key4hep-stack/common.py
@@ -139,7 +139,7 @@ def ilc_url_for_version(self, version):
         version_str = "v%02d-%02d.tar.gz" % (major, minor)
     elif isinstance(patch, int):
         version_str = "v%02d-%02d-%02d.tar.gz" % (major, minor, patch)
-    else: # allow for v00-04-pre
+    else:  # allow for v00-04-pre
         version_str = "v%02d-%02d-%s.tar.gz" % (major, minor, patch)
     return base_url + "/" + version_str
 

--- a/packages/key4hep-stack/common.py
+++ b/packages/key4hep-stack/common.py
@@ -137,8 +137,10 @@ def ilc_url_for_version(self, version):
     # on the value of the patch version
     if patch == 0:
         version_str = "v%02d-%02d.tar.gz" % (major, minor)
-    else:
+    elif isinstance(patch, int):
         version_str = "v%02d-%02d-%02d.tar.gz" % (major, minor, patch)
+    else: # allow for v00-04-pre
+        version_str = "v%02d-%02d-%s.tar.gz" % (major, minor, patch)
     return base_url + "/" + version_str
 
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Support `ilc_url_for_version` support for v00-04-pre patch levels

ENDRELEASENOTES

Until now, we had:
```
$ spack versions marlindd4hep 
==> Safe versions (already checksummed):
  master  0.6.2  0.6.1  0.6
==> Error: %d format: a real number is required, not VersionStrComponent
```
but with this fix we have:
```
$ spack --backtrace versions marlindd4hep ==> Safe versions (already checksummed):
  master  0.6.2  0.6.1  0.6
==> Remote versions (not yet checksummed):
  00-05  00-04-pre  00-04
```

This allows for better programmatic version parsing support.