### PR TITLE
Add a new environment that doesn't pick up anything from CVMFS

### DIFF
--- a/.github/scripts/concretize-tag-spack.sh
+++ b/.github/scripts/concretize-tag-spack.sh
@@ -1,8 +1,8 @@
 cd /
-if [ -z "$2" ]; then
+if [ -z "$1" ]; then
   tag=$(curl -s https://api.github.com/repos/spack/spack/releases/latest | grep '"tag_name":' | cut -d'"' -f4)
 else
-  tag="$2"
+  tag="$1"
 fi
 echo "Checking out the spack tag: $tag"
 git clone https://github.com/spack/spack -q -b $tag
@@ -12,15 +12,7 @@ cd /spack
 # git checkout $(cat /key4hep-spack/.latest-commit)
 # source /key4hep-spack/.cherry-pick
 
-if [ "$1" = "release" ]; then
-    env=key4hep-release-opt
-elif [ "$1" = "nightly" ]; then
-    env=key4hep-nightly-opt
-else
-    echo "Unknown build type"
-    exit 1
-fi
-cd /key4hep-spack/environments/${env}
+cd /key4hep-spack/environments/key4hep-base
 
 echo "========="
 echo "spack.yaml"

--- a/.github/workflows/concretize-latest-spack.yaml
+++ b/.github/workflows/concretize-latest-spack.yaml
@@ -10,12 +10,11 @@ on:
 jobs:
   concretize:
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.image }}-${{ matrix.build_type }}
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.image }}
       cancel-in-progress: true
     strategy:
       matrix:
         image: [alma9, ubuntu22]
-        build_type: [release, nightly]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -41,7 +40,7 @@ jobs:
             cat <<'EOF' > ${GITHUB_WORKSPACE}/script_container.sh
             set -e
 
-            /key4hep-spack/.github/scripts/concretize-tag-spack.sh "${{ matrix.build_type }}"
+            /key4hep-spack/.github/scripts/concretize-tag-spack.sh
 
             EOF
 

--- a/environments/README.md
+++ b/environments/README.md
@@ -1,0 +1,47 @@
+# Environments
+
+There are several folders with configuration files related to Spack
+environments. Some folders may pick up data files that are on cvmfs, and may not
+be suitable for every use-case.
+
+## key4hep-base
+
+This is a barebones environment and is the preferred one to use for building or
+concretizing the Key4hep stack independently. It will pick up only the
+configuration in `key4hep-common`, and is tested in CI to concretize against the
+latest tagged version of Spack.
+
+## key4hep-common and key4hep-common-{opt,dbg}
+
+These are configuration folders and contain the common requirements and variants
+that are used for the stacks that are on cvmfs. The configuration in
+`key4hep-common` is always picked up, and the configuration in
+`key4hep-common-{opt,dbg}` is picked up depending on the build type. A python
+script is used to make sure the configuration files in one folder don't override
+the settings for the same package in another configuration folder.
+
+## key4hep-{nightly,release}-share
+
+These are used to install common files for all nightlies and releases (like the
+Geant4 data files), and contain the location of the installed packages on cvmfs
+to avoid always reinstalling them.
+
+## key4hep-{nightly,release}-{opt,dbg}
+
+These contain configuration that is different depending on the build type, and
+are used for building the Key4hep stack on cvmfs.
+
+## key4hep-nightly-macos
+
+This is an experimental environment to build on MacOS. Builds of the Key4hep
+stack on MacOS are not guaranteed to build nor work.
+
+## key4hep-dev-external
+
+This is an environment to build the `key4hep-external-stack`, that contains many
+of the dependencies (like ROOT, Geant4, Gaudi, etc.) that are used to build the
+Key4hep stack and can be used for other projects.
+
+## contrib-compilers
+
+This is an environment used to install compilers on CVMFS.

--- a/environments/key4hep-base/spack.yaml
+++ b/environments/key4hep-base/spack.yaml
@@ -1,0 +1,9 @@
+spack:
+  view: false
+  include:
+  - ../key4hep-common/config-nightlies.yaml
+  - ../key4hep-common/packages.yaml
+  repos:
+  - ../..
+  specs:
+  - key4hep-stack+devtools

--- a/environments/key4hep-base/spack.yaml
+++ b/environments/key4hep-base/spack.yaml
@@ -1,7 +1,6 @@
 spack:
   view: false
   include:
-  - ../key4hep-common/config-nightlies.yaml
   - ../key4hep-common/packages.yaml
   repos:
   - ../..

--- a/environments/key4hep-common/packages.yaml
+++ b/environments/key4hep-common/packages.yaml
@@ -43,7 +43,7 @@ packages:
   rivet:
     require: '@:3 hepmc=3'
   podio:
-    require: +datasource+rntuple+rpath+sio
+    require: +datasource+rntuple+sio
   py-numpy:
     require: ^openblas
   # https://github.com/key4hep/key4hep-spack/issues/474


### PR DESCRIPTION
As discovered in https://github.com/key4hep/key4hep-spack/pull/700, concretizing using the latest tag of Spack won't work because new datafiles are provided in `environments/key4hep-{nightly,release}-share/packages.yaml` for Geant4 11.3.0, which is not available in the latest tag of Spack. Following up on https://github.com/key4hep/key4hep-spack/issues/692, a new environment that does not pick up stuff specific to the installation of the Key4hep stack on CVMFS is provided, so that it should be able to work a bit more independently (still, the requirements in `key4hep-common` are picked up since otherwise it could be a very different build).