### PR TITLE
k4rectracker: add v0.4.0 and a dependency on pandorasdk

### DIFF
--- a/packages/k4rectracker/package.py
+++ b/packages/k4rectracker/package.py
@@ -11,6 +11,10 @@ class K4rectracker(CMakePackage, Key4hepPackage):
 
     version("master", branch="master")
     version(
+        "0.4.0",
+        sha256="c93d75df8d219d821617b9365ef3034aa5ba69617a626585f438f2f06bfa8e5f",
+    )
+    version(
         "0.3.0",
         sha256="e945be69b1b4d51b07e8e806e366893af84369a9d63b04deee691aa10d591a02",
     )
@@ -24,6 +28,7 @@ class K4rectracker(CMakePackage, Key4hepPackage):
     # This shouldn't be necessary but the debug builds are failing because lcio can't be found
     # It started happening after adding marlinutil to the dependencies
     depends_on("lcio")
+    depends_on("pandorasdk", when="@0.4.0:")
 
     def cmake_args(self):
         args = []


### PR DESCRIPTION
Introduced in https://github.com/key4hep/k4RecTracker/pull/24