### PR TITLE
Fix for docker image push permission failure

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
     - main
+    - docker-fix
   workflow_dispatch:
 
 env:
@@ -52,7 +53,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ github.repository_owner }}/key4hep-externals
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/key4hep-externals
       - name: Determine spack ref
         id: getref
         run: |

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
     - main
-    - docker-fix
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
BEGINRELEASENOTES
- Fixed the publishing of key4hep-externals image

ENDRELEASENOTES

This PR implements a fix for the failing workflow adding an explicit reference to the registry that the metadata step should target