### PR TITLE
Add latest tag for k4edm4hep2lcioconv

### DIFF
--- a/packages/k4edm4hep2lcioconv/package.py
+++ b/packages/k4edm4hep2lcioconv/package.py
@@ -18,8 +18,13 @@ class K4edm4hep2lcioconv(CMakePackage, Key4hepPackage):
 
     version("main", branch="main")
     version(
+        "00-11",
+        sha256="f550ba488ed49ec7b41b9543a232e41409f8ae4e6bbe559649321599c5983488",
+    )
+    version(
         "00-10",
         sha256="d0d082d9dee973819d7713d883507a0303dbd917fb14c3749a4ffcdafc4e4af2",
+        deprecated=True,  # Cannot be consumed via CMake with version requirements
     )
     version(
         "00-09",

--- a/packages/k4edm4hep2lcioconv/package.py
+++ b/packages/k4edm4hep2lcioconv/package.py
@@ -18,6 +18,10 @@ class K4edm4hep2lcioconv(CMakePackage, Key4hepPackage):
 
     version("main", branch="main")
     version(
+        "00-10",
+        sha256="d0d082d9dee973819d7713d883507a0303dbd917fb14c3749a4ffcdafc4e4af2",
+    )
+    version(
         "00-09",
         sha256="bdbb88e2900eb3834d74d100b4d32ae760ee0816ac5fa4a5930772fbe9fb11d9",
     )

--- a/packages/k4marlinwrapper/package.py
+++ b/packages/k4marlinwrapper/package.py
@@ -37,10 +37,13 @@ class K4marlinwrapper(CMakePackage, Ilcsoftpackage):
     depends_on("gaudi")
     depends_on("k4fwcore")
     depends_on("k4fwcore@:1.1.0", when="@:0.9")
+    depends_on("k4fwcore@1.2:", when="@0.11:")
     depends_on("edm4hep")
     depends_on("edm4hep@0.10.1:")
     depends_on("k4edm4hep2lcioconv")
     depends_on("k4edm4hep2lcioconv@00-09:", when="@0.9:")
+    depends_on("k4edm4hep2lcioconv@00-10:", when="@0.11:")
+
     # for the doctest:
     depends_on("py-jupytext", type=("test"))
     depends_on("py-ipykernel", type=("test"))

--- a/packages/k4marlinwrapper/package.py
+++ b/packages/k4marlinwrapper/package.py
@@ -18,6 +18,10 @@ class K4marlinwrapper(CMakePackage, Ilcsoftpackage):
 
     version("main", branch="main")
     version(
+        "0.11",
+        sha256="e60a10c9ae1df3e07fb4823f12aba9dd0d8c32c7ee0e47583483fff8a6b0874e",
+    )
+    version(
         "0.10",
         sha256="7f04596f3825d0a8a9eb37aaeb546e03b245f8cb55fd5cdf2139e1ee2e8349ce",
     )
@@ -42,7 +46,7 @@ class K4marlinwrapper(CMakePackage, Ilcsoftpackage):
     depends_on("edm4hep@0.10.1:")
     depends_on("k4edm4hep2lcioconv")
     depends_on("k4edm4hep2lcioconv@00-09:", when="@0.9:")
-    depends_on("k4edm4hep2lcioconv@00-10:", when="@0.11:")
+    depends_on("k4edm4hep2lcioconv@00-11:", when="@0.11:")
 
     # for the doctest:
     depends_on("py-jupytext", type=("test"))


### PR DESCRIPTION
Just adding this commit here. Can also be moved to e.g. #700 

- [x] Add new tag hash for k4MarlinWrapper once nightlies have built tonight