### PR TITLE
Add new versions for k4FWCore, k4EDM4hep2LcioConv and k4MarlinWrapper

### DIFF
--- a/.github/workflows/concretize-current-nightly.yaml
+++ b/.github/workflows/concretize-current-nightly.yaml
@@ -66,7 +66,6 @@ jobs:
                 env=key4hep-release
             elif [ "${{ matrix.build_type }}" = "nightly" ]; then
                 env=key4hep-nightly-opt
-                pip3 install pyyaml
                 python3 /key4hep-spack/scripts/fetch_nightly_versions.py --path /key4hep-spack/environments/key4hep-common/packages.yaml --extra-path /key4hep-spack/environments/key4hep-common-opt/packages.yaml ""
             else
                 echo "Unknown build type"

--- a/.github/workflows/concretize.yaml
+++ b/.github/workflows/concretize.yaml
@@ -52,7 +52,6 @@ jobs:
                 env=key4hep-release-opt
             elif [ "${{ matrix.build_type }}" = "nightly" ]; then
                 env=key4hep-nightly-opt
-                pip3 install pyyaml
                 python3 /key4hep-spack/scripts/fetch_nightly_versions.py --path /key4hep-spack/environments/key4hep-common/packages.yaml --extra-path /key4hep-spack/environments/key4hep-common-opt/packages.yaml ""
             else
                 echo "Unknown build type"

--- a/environments/key4hep-base/spack.yaml
+++ b/environments/key4hep-base/spack.yaml
@@ -2,6 +2,7 @@ spack:
   view: false
   include:
   - ../key4hep-common/packages.yaml
+  - ../key4hep-common/compilers.yaml
   repos:
   - ../..
   specs:

--- a/packages/k4edm4hep2lcioconv/package.py
+++ b/packages/k4edm4hep2lcioconv/package.py
@@ -26,35 +26,11 @@ class K4edm4hep2lcioconv(CMakePackage, Key4hepPackage):
     version(
         "00-10",
         sha256="a7fbdb0dfc3082b71f158a1c0a7f3c7698901b1f2bc9204cf7e9c656ae142884",
+        deprecated=True,
     )
     version(
         "00-09",
-        sha256="bdbb88e2900eb3834d74d100b4d32ae760ee0816ac5fa4a5930772fbe9fb11d9",
-    )
-    version(
-        "00-08-02",
-        sha256="a0418b5c3c6ce77435bd942279420b0390099f417a7984227cf212710b079321",
-        deprecated=True,
-    )
-    version(
-        "00-08-01",
-        sha256="4518e39a0c87182d394f213074344ed29724005cd0481a2555a1fe48fdb98d2b",
-        deprecated=True,
-    )
-    version(
-        "00-08",
-        sha256="e3bfcb611b78d8e457d7f68e25d5aabe21b4b87928b0de0fc61a09734c7adb4c",
-        deprecated=True,
-    )
-    version(
-        "00-07",
-        sha256="269d14c390f987fb3fdb0d2e952febfb639415bef50e5e1c8992f23e0cd4a5a6",
-        deprecated=True,
-    )
-    version(
-        "00-06",
-        sha256="c220604577d309bc11a5a4c147f55640fedef90375d1232439343362607a3906",
-        deprecated=True,
+        sha256="aae9ac39ae56f9e18b8b2f13c84ca95a2c90b71069a5318b894a574d773d8815",
     )
 
     depends_on("lcio@2.20:")

--- a/packages/k4edm4hep2lcioconv/package.py
+++ b/packages/k4edm4hep2lcioconv/package.py
@@ -12,11 +12,21 @@ class K4edm4hep2lcioconv(CMakePackage, Key4hepPackage):
 
     homepage = "https://github.com/key4hep/k4EDM4hep2LcioConv"
     git = "https://github.com/key4hep/k4EDM4hep2LcioConv.git"
-    url = "https://github.com/key4hep/k4EDM4hep2LcioConv/archive/v00-01.zip"
+    url = (
+        "https://github.com/key4hep/k4EDM4hep2LcioConv/archive/refs/tags/v00-10.tar.gz"
+    )
 
     maintainers = ["tmadlener"]
 
     version("main", branch="main")
+    version(
+        "00-11",
+        sha256="937c9a794f094395134ed4df448fda643e0ba4a339b7ee1d8d2e4ea08f4ee2f7",
+    )
+    version(
+        "00-10",
+        sha256="a7fbdb0dfc3082b71f158a1c0a7f3c7698901b1f2bc9204cf7e9c656ae142884",
+    )
     version(
         "00-09",
         sha256="bdbb88e2900eb3834d74d100b4d32ae760ee0816ac5fa4a5930772fbe9fb11d9",

--- a/packages/k4fwcore/package.py
+++ b/packages/k4fwcore/package.py
@@ -12,6 +12,10 @@ class K4fwcore(CMakePackage, Ilcsoftpackage):
     version("main", branch="main")
 
     version(
+        "1.2.0",
+        sha256="df10ab72beebd87d26a7945003dd166bd49fa4afd39638658b1723bdda5a17b6",
+    )
+    version(
         "1.1.2",
         sha256="5451f1644357ac8ced0f5fc984809f4a48bdf2f4baf25a0a2f70540ed0427ac4",
     )

--- a/packages/k4marlinwrapper/package.py
+++ b/packages/k4marlinwrapper/package.py
@@ -18,6 +18,10 @@ class K4marlinwrapper(CMakePackage, Ilcsoftpackage):
 
     version("main", branch="main")
     version(
+        "0.11",
+        sha256="e60a10c9ae1df3e07fb4823f12aba9dd0d8c32c7ee0e47583483fff8a6b0874e",
+    )
+    version(
         "0.10",
         sha256="7f04596f3825d0a8a9eb37aaeb546e03b245f8cb55fd5cdf2139e1ee2e8349ce",
     )

--- a/packages/k4marlinwrapper/package.py
+++ b/packages/k4marlinwrapper/package.py
@@ -45,7 +45,6 @@ class K4marlinwrapper(CMakePackage, Ilcsoftpackage):
     depends_on("edm4hep")
     depends_on("edm4hep@0.10.1:")
     depends_on("k4edm4hep2lcioconv")
-    depends_on("k4edm4hep2lcioconv@00-09:", when="@0.9:")
     depends_on("k4edm4hep2lcioconv@:00-10", when="@:0.10")
     depends_on("k4edm4hep2lcioconv@00-11:", when="@0.11:")
     # for the doctest:

--- a/packages/k4marlinwrapper/package.py
+++ b/packages/k4marlinwrapper/package.py
@@ -41,10 +41,13 @@ class K4marlinwrapper(CMakePackage, Ilcsoftpackage):
     depends_on("gaudi")
     depends_on("k4fwcore")
     depends_on("k4fwcore@:1.1.0", when="@:0.9")
+    depends_on("k4fwcore@1.2.0:", when="@0.11:")
     depends_on("edm4hep")
     depends_on("edm4hep@0.10.1:")
     depends_on("k4edm4hep2lcioconv")
     depends_on("k4edm4hep2lcioconv@00-09:", when="@0.9:")
+    depends_on("k4edm4hep2lcioconv@:00-10", when="@:0.10")
+    depends_on("k4edm4hep2lcioconv@00-11:", when="@0.11:")
     # for the doctest:
     depends_on("py-jupytext", type=("test"))
     depends_on("py-ipykernel", type=("test"))


### PR DESCRIPTION
And while we're at it, remove deprecated versions of `k4EDM4hep2LcioConv` and use the `tar.gz` files, simply because this is how it is done in most packages. Make a few changes to make CI pass.