### PR TITLE
Removed externals view-dependent setup 

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
     - main
+    - fix-externals-view
   workflow_dispatch:
 
 env:

--- a/Docker/AlmaLinux9/Dockerfile-externals
+++ b/Docker/AlmaLinux9/Dockerfile-externals
@@ -10,6 +10,9 @@ ARG SPACK_COMMIT=6cb16c39ab85fbc211e50be804fa7a15f24ccebc
 ARG COMMIT_SHA=e49a0639ff987a84fa0c6263e068776f9d7b6f67
 ARG GITHUB_REPOSITORY=madbaron/key4hep-spack
 
+# Install gcc
+RUN dnf install -y gcc gcc-c++ gcc-gfortran
+
 # Setting up Spack
 RUN git clone https://github.com/spack/spack.git /opt/spack && \
     echo "source /opt/spack/share/spack/setup-env.sh" >> /opt/setup_spack.sh && \
@@ -24,7 +27,6 @@ RUN if [ -n "${SPACK_COMMIT}" ]; then \
 # Registering compilers with Spack
 ENV SPACK_COLOR="always"
 RUN source /opt/setup_spack.sh && \
-    /mount.sh && \
     spack compiler find
 
 RUN source /opt/setup_spack.sh && \

--- a/Docker/AlmaLinux9/Dockerfile-externals
+++ b/Docker/AlmaLinux9/Dockerfile-externals
@@ -67,5 +67,6 @@ RUN source ${HOME}/setup_env.sh && \
     spack clean -a
 
 RUN source ${HOME}/setup_env.sh && \
-    echo "source ${SPACK_ENV}/.spack-env/view/setup.sh" > /opt/setup_k4_externals.sh && \
+    KEY4HEP_EXTERNALS_STACK_PATH=$(spack find --format "{prefix}" key4hep-external-stack) && \
+    echo "source ${KEY4HEP_EXTERNALS_STACK_PATH}/setup.sh" > /opt/setup_k4_externals.sh && \
     echo "alias setup_k4_externals=\"source /opt/setup_k4_externals.sh\"" >> /etc/profile.d/aliases.sh

--- a/Docker/AlmaLinux9/Dockerfile-externals
+++ b/Docker/AlmaLinux9/Dockerfile-externals
@@ -65,8 +65,3 @@ RUN source ${HOME}/setup_env.sh && \
     spack spec -NIt && \
     spack install ${SPACK_INSTALL_OPTS} && \
     spack clean -a
-
-RUN source ${HOME}/setup_env.sh && \
-    KEY4HEP_EXTERNALS_STACK_PATH=$(spack find --format "{prefix}" key4hep-external-stack) && \
-    echo "source ${KEY4HEP_EXTERNALS_STACK_PATH}/setup.sh" > /opt/setup_k4_externals.sh && \
-    echo "alias setup_k4_externals=\"source /opt/setup_k4_externals.sh\"" >> /etc/profile.d/aliases.sh

--- a/Docker/AlmaLinux9/Dockerfile-externals
+++ b/Docker/AlmaLinux9/Dockerfile-externals
@@ -3,7 +3,7 @@
 #  Tag:        ${VERSION}-alma9
 ###############################################################################
 
-FROM ghcr.io/key4hep/key4hep-images/alma9-cvmfs:latest
+FROM ghcr.io/key4hep/key4hep-images/alma9:latest
 
 # Picking specific commits
 ARG SPACK_COMMIT=6cb16c39ab85fbc211e50be804fa7a15f24ccebc

--- a/Docker/AlmaLinux9/Dockerfile-externals
+++ b/Docker/AlmaLinux9/Dockerfile-externals
@@ -10,8 +10,8 @@ ARG SPACK_COMMIT=6cb16c39ab85fbc211e50be804fa7a15f24ccebc
 ARG COMMIT_SHA=e49a0639ff987a84fa0c6263e068776f9d7b6f67
 ARG GITHUB_REPOSITORY=madbaron/key4hep-spack
 
-# Install gcc
-RUN dnf install -y gcc gcc-c++ gcc-gfortran lbzip2
+# Install gcc and lbzip2
+RUN dnf install -y gcc gcc-c++ gcc-gfortran lbzip2 unzip
 
 # Setting up Spack
 RUN git clone https://github.com/spack/spack.git /opt/spack && \

--- a/Docker/AlmaLinux9/Dockerfile-externals
+++ b/Docker/AlmaLinux9/Dockerfile-externals
@@ -24,6 +24,7 @@ RUN if [ -n "${SPACK_COMMIT}" ]; then \
 # Registering compilers with Spack
 ENV SPACK_COLOR="always"
 RUN source /opt/setup_spack.sh && \
+    /mount.sh && \
     spack compiler find
 
 RUN source /opt/setup_spack.sh && \

--- a/Docker/AlmaLinux9/Dockerfile-externals
+++ b/Docker/AlmaLinux9/Dockerfile-externals
@@ -11,7 +11,7 @@ ARG COMMIT_SHA=e49a0639ff987a84fa0c6263e068776f9d7b6f67
 ARG GITHUB_REPOSITORY=madbaron/key4hep-spack
 
 # Install gcc
-RUN dnf install -y gcc gcc-c++ gcc-gfortran
+RUN dnf install -y gcc gcc-c++ gcc-gfortran lbzip2
 
 # Setting up Spack
 RUN git clone https://github.com/spack/spack.git /opt/spack && \

--- a/Docker/AlmaLinux9/Dockerfile-externals
+++ b/Docker/AlmaLinux9/Dockerfile-externals
@@ -3,7 +3,7 @@
 #  Tag:        ${VERSION}-alma9
 ###############################################################################
 
-FROM ghcr.io/key4hep/key4hep-images/alma9:latest
+FROM ghcr.io/key4hep/key4hep-images/alma9-cvmfs:latest
 
 # Picking specific commits
 ARG SPACK_COMMIT=6cb16c39ab85fbc211e50be804fa7a15f24ccebc

--- a/environments/key4hep-dev-external/spack.yaml
+++ b/environments/key4hep-dev-external/spack.yaml
@@ -1,4 +1,8 @@
 spack:
+
+  include:
+  - ../key4hep-common/compilers.yaml
+
   packages:
     all:
       variants:

--- a/environments/key4hep-dev-external/spack.yaml
+++ b/environments/key4hep-dev-external/spack.yaml
@@ -1,8 +1,5 @@
 spack:
 
-  include:
-  - ../key4hep-common/compilers.yaml
-
   packages:
     all:
       variants:


### PR DESCRIPTION
BEGINRELEASENOTES
- Removed setup script dependent of missing view
- Updated key4hep-externals workflow to run with modified upstream images
ENDRELEASENOTES

This PR removes the (broken) setup script based on the env view, which was not generated.
The docker recipe is also updated to take into account changes done to the images upstream