### PR TITLE
Fix k4FWCore v1.2

### DIFF
--- a/packages/k4fwcore/package.py
+++ b/packages/k4fwcore/package.py
@@ -12,7 +12,7 @@ class K4fwcore(CMakePackage, Ilcsoftpackage):
     version("main", branch="main")
 
     version(
-        "1.2.0",
+        "1.2",
         sha256="4405a3d6e88845807d57849a759827ad988681c31c9e63851b9f7d30c9a407e4",
     )
     version(

--- a/packages/k4fwcore/package.py
+++ b/packages/k4fwcore/package.py
@@ -13,7 +13,7 @@ class K4fwcore(CMakePackage, Ilcsoftpackage):
 
     version(
         "1.2.0",
-        sha256="df10ab72beebd87d26a7945003dd166bd49fa4afd39638658b1723bdda5a17b6",
+        sha256="4405a3d6e88845807d57849a759827ad988681c31c9e63851b9f7d30c9a407e4",
     )
     version(
         "1.1.2",


### PR DESCRIPTION
An extra -00 was added originally in the tag and now that it has been fixed the hash is different

Tagging @madbaron and @tmadlener 