### PR TITLE
Make sure to not be too specific in dependency

### DIFF
--- a/packages/k4marlinwrapper/package.py
+++ b/packages/k4marlinwrapper/package.py
@@ -41,7 +41,7 @@ class K4marlinwrapper(CMakePackage, Ilcsoftpackage):
     depends_on("gaudi")
     depends_on("k4fwcore")
     depends_on("k4fwcore@:1.1.0", when="@:0.9")
-    depends_on("k4fwcore@1.2.0:", when="@0.11:")
+    depends_on("k4fwcore@1.2:", when="@0.11:")
     depends_on("edm4hep")
     depends_on("edm4hep@0.10.1:")
     depends_on("k4edm4hep2lcioconv")


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove a spurious `.0` from a version to allow spack to actually concretize to the latest version of `k4marlinwrapper`.

ENDRELEASENOTES

@madbaron this should fix our mucoll-spack issue.
@jmcarcell I will merge this rather quickly to get a new external-image going