### PR TITLE
Remove outdated or wrong llvm variants

### DIFF
--- a/environments/key4hep-common/packages.yaml
+++ b/environments/key4hep-common/packages.yaml
@@ -37,7 +37,7 @@ packages:
   lccontent:
     require: +monitoring
   llvm:
-    variants: ~flang~lldb~lld~lua~mlir~internal_unwind~polly~libomptarget~libomptarget_debug~gold~split_dwarf~llvm_dylib~link_llvm_dylib~omp_tsan~omp_as_runtime~code_signing~python~version_suffix~shlib_symbol_version~z3~zstd compiler-rt="none" libcxx="none" targets="x86"
+    variants: ~flang~lldb~lld~lua~mlir~polly~libomptarget~libomptarget_debug~gold~split_dwarf~llvm_dylib~link_llvm_dylib~code_signing~python~z3~zstd compiler-rt="none" libcxx="none" targets="x86"
   marlin:
     require: +lccd
   madgraph5amc:


### PR DESCRIPTION
These variants have either been removed quite some time ago, or are not binary variants and will lead to problems with the latest versions of spack (see https://github.com/spack/spack/issues/49340)


BEGINRELEASENOTES
- Fix potentially troublesome variants for llvm

ENDRELEASENOTES
