### PR TITLE
Revert "Add the latest commit of simsipm to be picked up in the nightlies"

### DIFF
--- a/environments/key4hep-common-dbg/packages.yaml
+++ b/environments/key4hep-common-dbg/packages.yaml
@@ -121,8 +121,6 @@ packages:
     require: build_type=Debug
   raida:
     require: build_type=Debug
-  simsipm:
-    require: build_type=Debug
   sio:
     require: build_type=Debug cxxstd=20
 

--- a/environments/key4hep-common-opt/packages.yaml
+++ b/environments/key4hep-common-opt/packages.yaml
@@ -121,8 +121,6 @@ packages:
     require: build_type=Release
   raida:
     require: build_type=Release
-  simsipm:
-    require: build_type=Release
   sio:
     require: build_type=Release cxxstd=20
 

--- a/scripts/fetch_nightly_versions.py
+++ b/scripts/fetch_nightly_versions.py
@@ -167,7 +167,6 @@ if __name__ == "__main__":
         ("physsim", "ilcsoft/physsim"),
         ("podio", "aidasoft/podio"),
         ("raida", "ilcsoft/raida"),
-        ("simsipm", "edopro98/simsipm"),
         ("sio", "ilcsoft/sio"),
     ]:
         if args.only_merge:


### PR DESCRIPTION
Reverts key4hep/key4hep-spack#726. It won't build because https://github.com/EdoPro98/SimSiPM/pull/17 is needed.