### PR TITLE
Add the correct path for py-torch to CMAKE_PREFIX_PATH at runtime

### DIFF
--- a/packages/key4hep-stack/package.py
+++ b/packages/key4hep-stack/package.py
@@ -176,5 +176,10 @@ class Key4hepStack(BundlePackage, Key4hepPackage):
         if "automake" in self.spec:
             env.prepend_path("PATH", self.spec["automake"].prefix.bin)
 
+        # Add the correct path in pytorch to CMAKE_PREFIX_PATH
+        # This could be deleted (to be tested) once https://github.com/spack/spack/pull/49267 is merged
+        if "py-torch" in self.spec:
+            env.prepend_path("CMAKE_PREFIX_PATH", join_path(self["py-torch"].module.python_platlib, "torch", "share", "cmake"))
+
     def install(self, spec, prefix):
         return install_setup_script(self, spec, prefix, "K4_LATEST_SETUP_PATH")

--- a/packages/key4hep-stack/package.py
+++ b/packages/key4hep-stack/package.py
@@ -179,7 +179,12 @@ class Key4hepStack(BundlePackage, Key4hepPackage):
         # Add the correct path in pytorch to CMAKE_PREFIX_PATH
         # This could be deleted (to be tested) once https://github.com/spack/spack/pull/49267 is merged
         if "py-torch" in self.spec:
-            env.prepend_path("CMAKE_PREFIX_PATH", join_path(self["py-torch"].module.python_platlib, "torch", "share", "cmake"))
+            env.prepend_path(
+                "CMAKE_PREFIX_PATH",
+                join_path(
+                    self["py-torch"].module.python_platlib, "torch", "share", "cmake"
+                ),
+            )
 
     def install(self, spec, prefix):
         return install_setup_script(self, spec, prefix, "K4_LATEST_SETUP_PATH")


### PR DESCRIPTION
Currently it is not set, meaning that after sourcing the stack projects will not find py-torch. It should be fixed in Spack with https://github.com/spack/spack/pull/49267.