### PR TITLE
Add a flag to link OpenMP for DDFastShowerML to fix builds on Ubuntu24

### DIFF
--- a/packages/ddfastshowerml/package.py
+++ b/packages/ddfastshowerml/package.py
@@ -36,7 +36,6 @@ class Ddfastshowerml(CMakePackage, Key4hepPackage):
     depends_on("openmpi", when="@0.1.1:")
 
     def cmake_args(self):
-
         args = [
             f"-DCMAKE_CXX_STANDARD={self.spec['root'].variants['cxxstd'].value}",
         ]

--- a/packages/ddfastshowerml/package.py
+++ b/packages/ddfastshowerml/package.py
@@ -36,8 +36,13 @@ class Ddfastshowerml(CMakePackage, Key4hepPackage):
     depends_on("openmpi", when="@0.1.1:")
 
     def cmake_args(self):
-        args = []
-        args.append(
-            f"-DCMAKE_CXX_STANDARD={self.spec['root'].variants['cxxstd'].value}"
-        )
+
+        args = [
+            f"-DCMAKE_CXX_STANDARD={self.spec['root'].variants['cxxstd'].value}",
+        ]
+        # This fixes issues in Ubuntu24 when it's not linking to libgomp from gcc-runtime
+        if self.spec.satisfies("inference=torch") or self.spec.satisfies(
+            "inference=both"
+        ):
+            args.append(f"-DCMAKE_SHARED_LINKER_FLAGS={self.compiler.openmp_flag}")
         return args


### PR DESCRIPTION
For some reason nightly builds of DDFastShowerML stopped working from one day to another without changes in Spack or DDFastShowerML. I don't understand what has happened.
The issue is that Spack is not linking to OpenMP, in this case `libgomp` provided by `gcc-runtime`. Adding the flag solves the issue:

```
     393    /usr/bin/ld: CMakeFiles/DDML.dir/TorchInference.cc.o: in function `
            ddml::TorchInference::initialize()':
  >> 394    TorchInference.cc:(.text+0x4b2): undefined reference to `omp_set_nu
            m_threads'
  >> 395    /usr/bin/ld: TorchInference.cc:(.text+0x4b7): undefined reference t
            o `omp_get_num_threads'
  >> 396    /usr/bin/ld: TorchInference.cc:(.text+0x4be): undefined reference t
            o `omp_get_max_threads'
```