### PR TITLE
Transfer private k4MLJetTagger to key4hep

### DIFF
--- a/packages/k4mljettagger/package.py
+++ b/packages/k4mljettagger/package.py
@@ -5,9 +5,9 @@ from spack.pkg.k4.key4hep_stack import Key4hepPackage
 class K4mljettagger(CMakePackage, Key4hepPackage):
     """Implementation of Jet-Flavor Tagging on CLD full simulation with the ParticleTransformer"""
 
-    homepage = "https://github.com/saracreates/k4MLJetTagger"
-    git = "https://github.com/saracreates/k4MLJetTagger.git"
-    # url = "https://github.com/saracreates/archive/v0.1.1.tar.gz"
+    homepage = "https://github.com/key4hep/k4MLJetTagger"
+    git = "https://github.com/key4hep/k4MLJetTagger.git"
+    # url = "https://github.com/key4hep/archive/v0.1.1.tar.gz"
 
     maintainers = ["jmcarcell"]
 

--- a/scripts/fetch_nightly_versions.py
+++ b/scripts/fetch_nightly_versions.py
@@ -130,6 +130,7 @@ if __name__ == "__main__":
         ("gear", "ilcsoft/gear"),
         ("ilcutil", "ilcsoft/ilcutil"),
         ("ildperformance", "ilcsoft/ildperformance"),
+        ("k4mljettagger", "key4hep/k4mljettagger"),
         ("k4clue", "key4hep/k4clue"),
         ("k4edm4hep2lcioconv", "key4hep/k4edm4hep2lcioconv"),
         ("k4fwcore", "key4hep/k4fwcore"),

--- a/scripts/fetch_nightly_versions.py
+++ b/scripts/fetch_nightly_versions.py
@@ -130,7 +130,6 @@ if __name__ == "__main__":
         ("gear", "ilcsoft/gear"),
         ("ilcutil", "ilcsoft/ilcutil"),
         ("ildperformance", "ilcsoft/ildperformance"),
-        ("k4mljettagger", "saracreates/k4mljettagger"),
         ("k4clue", "key4hep/k4clue"),
         ("k4edm4hep2lcioconv", "key4hep/k4edm4hep2lcioconv"),
         ("k4fwcore", "key4hep/k4fwcore"),


### PR DESCRIPTION
BEGINRELEASENOTES
- Transferred private repo k4MLJetTagger to key4hep, therefore some changes in spark are needed
- renamed "saracreates" to "key4hep" in paths to repo
- renamed line with saracreates in `fetch_nightly_version.py` to key4hep

ENDRELEASENOTES
