### PR TITLE
k4geo: Make sure to install the CAD beampipe files

### DIFF
--- a/packages/k4geo/package.py
+++ b/packages/k4geo/package.py
@@ -57,6 +57,7 @@ class K4geo(CMakePackage):
         )
         args.append(self.define_from_variant("INSTALL_COMPACT_FILES", "compact"))
         args.append(self.define("BUILD_TESTING", self.run_tests))
+        args.append("-DINSTALL_BEAMPIPE_STL_FILES=ON")
         return args
 
     def setup_run_environment(self, env):

--- a/packages/k4geo/package.py
+++ b/packages/k4geo/package.py
@@ -56,8 +56,9 @@ class K4geo(CMakePackage):
             f"-DCMAKE_CXX_STANDARD={self.spec['root'].variants['cxxstd'].value}"
         )
         args.append(self.define_from_variant("INSTALL_COMPACT_FILES", "compact"))
+        # Automatically install the CAD beampipe files if we install the compact files
+        args.append(self.define("INSTALL_BEAMPIPE_STL_FILES", self.comapact))
         args.append(self.define("BUILD_TESTING", self.run_tests))
-        args.append("-DINSTALL_BEAMPIPE_STL_FILES=ON")
         return args
 
     def setup_run_environment(self, env):

--- a/packages/k4geo/package.py
+++ b/packages/k4geo/package.py
@@ -57,7 +57,7 @@ class K4geo(CMakePackage):
         )
         args.append(self.define_from_variant("INSTALL_COMPACT_FILES", "compact"))
         # Automatically install the CAD beampipe files if we install the compact files
-        args.append(self.define("INSTALL_BEAMPIPE_STL_FILES", self.comapact))
+        args.append(self.define("INSTALL_BEAMPIPE_STL_FILES", self.compact))
         args.append(self.define("BUILD_TESTING", self.run_tests))
         return args
 


### PR DESCRIPTION
Fixes our failing CI: https://github.com/iLCSoft/ILDConfig/actions/runs/14397238523/job/40375061669#step:4:161


BEGINRELEASENOTES
- Make sure to install the FCC MDI CAD files in k4geo

ENDRELEASENOTES
