### PR TITLE
Add missing dependencies for k4GaudiPandora and k4RecCalorimeter

### DIFF
--- a/packages/k4gaudipandora/package.py
+++ b/packages/k4gaudipandora/package.py
@@ -26,6 +26,9 @@ class K4gaudipandora(CMakePackage, Key4hepPackage):
     depends_on("pandorasdk")
     depends_on("root")
 
+    # Used in the tests
+    depends_on("k4geo")
+
     def setup_run_environment(self, env):
         env.prepend_path("LD_LIBRARY_PATH", self.spec["k4gaudipandora"].prefix.lib)
 

--- a/packages/k4reccalorimeter/package.py
+++ b/packages/k4reccalorimeter/package.py
@@ -42,6 +42,7 @@ class K4reccalorimeter(CMakePackage, Key4hepPackage):
     depends_on("podio")
     depends_on("py-onnxruntime")
     depends_on("root")
+    depends_on("simsipm")
 
     def cmake_args(self):
         args = []


### PR DESCRIPTION
Nightlies are failing because of recent changes in these repositories.