### PR TITLE
Add a message about deprecating Ubuntu 22.04

### DIFF
--- a/scripts/cvmfs/setup-nightlies.sh
+++ b/scripts/cvmfs/setup-nightlies.sh
@@ -36,6 +36,7 @@ function list_releases() {
             compiler="gcc14"
         fi
     elif [ "$os" = "ubuntu22" ]; then
+        echo "Warning: Ubuntu 22.04 is deprecated, please use Ubuntu 24.04"
         name="ubuntu22"
     elif [ "$os" = "ubuntu" ] || [ "$os" = "ubuntu24" ]; then
         name="ubuntu24"
@@ -62,6 +63,7 @@ function list_packages() {
             compiler="gcc14"
         fi
     elif [ "$os" = "ubuntu22" ]; then
+        echo "Warning: Ubuntu 22.04 is deprecated, please use Ubuntu 24.04"
         name="ubuntu22"
     elif [ "$os" = "ubuntu" ] || [ "$os" = "ubuntu24" ]; then
         name="ubuntu24"
@@ -207,6 +209,7 @@ if [[ "$(grep -E '^ID=' /etc/os-release)" = 'ID="almalinux"' && "$(grep -E 'VERS
     os="almalinux9"
 elif [[ "$(grep -E '^ID=' /etc/os-release)" = 'ID=ubuntu' && "$(grep -E 'VERSION_ID' /etc/os-release)" = 'VERSION_ID="22.04"' ]] ||
      [[ "$(grep -E '^ID=' /etc/os-release)" = 'ID=pop' && "$(grep -E 'VERSION_ID' /etc/os-release)" = 'VERSION_ID="22.04"' ]]; then
+    echo "Warning: Ubuntu 22.04 is deprecated, please use Ubuntu 24.04"
     os="ubuntu22"
 elif [[ "$(grep -E '^ID=' /etc/os-release)" = 'ID=ubuntu' && "$(grep -E 'VERSION_ID' /etc/os-release)" = 'VERSION_ID="24.04"' ]] ||
      [[ "$(grep -E '^ID=' /etc/os-release)" = 'ID=pop' && "$(grep -E 'VERSION_ID' /etc/os-release)" = 'VERSION_ID="24.04"' ]]; then


### PR DESCRIPTION
We have had support for Ubuntu 24.04 and supporting GCC 11 is a bit annoying
since, for example, Gaudi doesn't build with GCC 11 so we always have to patch
it. And over time this will only get worse. 

See also https://github.com/key4hep/key4hep-spack/issues/737. After some time,
I'll delete the Ubuntu nightlies since anyway they are old.