### PR TITLE
Update the way maintainers are specified

### DIFF
--- a/packages/aidatt/package.py
+++ b/packages/aidatt/package.py
@@ -14,7 +14,7 @@ class Aidatt(CMakePackage, Ilcsoftpackage):
     url = "https://github.com/AIDASoft/aidaTT/archive/v00-10.tar.gz"
     git = "https://github.com/AIDASoft/aidaTT.git"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="master")
     version(

--- a/packages/ced/package.py
+++ b/packages/ced/package.py
@@ -14,7 +14,7 @@ class Ced(CMakePackage, Ilcsoftpackage):
     url = "https://github.com/iLCSoft/CED/archive/v01-09-03.tar.gz"
     git = "https://github.com/iLCSoft/CED.git"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="master")
     version(

--- a/packages/cedviewer/package.py
+++ b/packages/cedviewer/package.py
@@ -14,7 +14,7 @@ class Cedviewer(CMakePackage, Ilcsoftpackage):
     homepage = "https://github.com/iLCSoft/CEDViewer"
     git = "https://github.com/iLCSoft/CEDViewer.git"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="master")
     version(

--- a/packages/cepcsw/package.py
+++ b/packages/cepcsw/package.py
@@ -9,7 +9,7 @@ class Cepcsw(CMakePackage, Key4hepPackage):
     url = "https://github.com/cepc/CEPCSW/archive/v0.1.tar.gz"
     git = "https://github.com/cepc/CEPCSW.git"
 
-    maintainers = ["mirguest"]
+    maintainers("mirguest")
 
     version("master", branch="master")
     version(

--- a/packages/cldconfig/package.py
+++ b/packages/cldconfig/package.py
@@ -13,7 +13,7 @@ class Cldconfig(CMakePackage):
     git = "https://github.com/key4hep/CLDConfig"
     url = "https://github.com/key4hep/CLDConfig/archive/refs/tags/r2024-10-06.tar.gz"
 
-    maintainers = ["jmcarcell"]
+    maintainers("jmcarcell")
 
     version("main", branch="main")
     version(

--- a/packages/clicperformance/package.py
+++ b/packages/clicperformance/package.py
@@ -14,7 +14,7 @@ class Clicperformance(CMakePackage, Ilcsoftpackage):
     homepage = "https://github.com/iLCSoft/ClicPerformance"
     git = "https://github.com/iLCSoft/ClicPerformance.git"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     generator = "Ninja"
 

--- a/packages/clupatra/package.py
+++ b/packages/clupatra/package.py
@@ -14,7 +14,7 @@ class Clupatra(CMakePackage, Ilcsoftpackage):
     homepage = "https://github.com/iLCSoft/Clupatra"
     git = "https://github.com/iLCSoft/Clupatra.git"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="master")
     version(

--- a/packages/conddbmysql/package.py
+++ b/packages/conddbmysql/package.py
@@ -14,7 +14,7 @@ class Conddbmysql(CMakePackage, Key4hepPackage):
     git = "https://github.com/iLCSoft/conddbmysql.git"
     url = "https://github.com/iLCSoft/CondDBMySQL/archive/CondDBMySQL_ILC-0-9-7.tar.gz"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="master")
     version(

--- a/packages/conformaltracking/package.py
+++ b/packages/conformaltracking/package.py
@@ -16,7 +16,7 @@ class Conformaltracking(CMakePackage, Ilcsoftpackage):
     url = "https://github.com/iLCSoft/ConformalTracking/archive/v01-10.tar.gz"
     git = "https://github.com/iLCSoft/ConformalTracking.git"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="master")
     version(

--- a/packages/ddfastshowerml/package.py
+++ b/packages/ddfastshowerml/package.py
@@ -14,7 +14,7 @@ class Ddfastshowerml(CMakePackage, Key4hepPackage):
     git = "https://gitlab.desy.de/ilcsoft/ddfastshowerml.git"
     url = "https://gitlab.desy.de/ilcsoft/ddfastshowerml/-/archive/v0.1.0/ddfastshowerml-v0.1.0.tar.gz"
 
-    maintainers = ["jmcarcell", "tmadlener"]
+    maintainers("jmcarcell", "tmadlener")
 
     version("main", branch="main")
     version(

--- a/packages/ddkaltest/package.py
+++ b/packages/ddkaltest/package.py
@@ -14,7 +14,7 @@ class Ddkaltest(CMakePackage, Ilcsoftpackage):
     url = "https://github.com/iLCSoft/DDKalTest/archive/v01-06.tar.gz"
     git = "https://github.com/iLCSoft/DDKalTest.git"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="master")
     version(

--- a/packages/ddmarlinpandora/package.py
+++ b/packages/ddmarlinpandora/package.py
@@ -14,7 +14,7 @@ class Ddmarlinpandora(CMakePackage, Ilcsoftpackage):
     homepage = "https://github.com/iLCSoft/DDMarlinPandora/archive/v00-11.tar.gz"
     git = "https://github.com/iLCSoft/DDMarlinPandora.git"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="master")
     version(

--- a/packages/dual-readout/package.py
+++ b/packages/dual-readout/package.py
@@ -14,7 +14,7 @@ class DualReadout(CMakePackage, Key4hepPackage):
     homepage = "https://github.com/HEP-FCC/dual-readout"
     git = "https://github.com/HEP-FCC/dual-readout.git"
 
-    maintainers = ["vvolkl", "SanghyunKo"]
+    maintainers("vvolkl", "SanghyunKo")
 
     version("master", branch="master")
 

--- a/packages/emela/package.py
+++ b/packages/emela/package.py
@@ -12,7 +12,7 @@ class Emela(CMakePackage):
     homepage = "https://github.com/jmcarcell/eMELA"
     url = "https://github.com/gstagnit/eMELA/archive/refs/tags/v1.0.tar.gz"
 
-    maintainers = ["jmcarcell"]
+    maintainers("jmcarcell")
 
     version(
         "1.0",

--- a/packages/fcalclusterer/package.py
+++ b/packages/fcalclusterer/package.py
@@ -15,7 +15,7 @@ class Fcalclusterer(CMakePackage, Ilcsoftpackage):
     homepage = "https://github.com/FCalSW/FCalClusterer"
     git = "https://github.com/FCalSW/FCalClusterer.git"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="master")
     version(

--- a/packages/fcc-config/package.py
+++ b/packages/fcc-config/package.py
@@ -13,7 +13,7 @@ class FccConfig(CMakePackage):
     url = "https://github.com/HEP-FCC/FCC-config/archive/refs/tags/v0.1.0.tar.gz"
     git = "https://github.com/HEP-FCC/FCC-config"
 
-    maintainers = ["jmcarcell"]
+    maintainers("jmcarcell")
 
     version("main", branch="main")
     version(

--- a/packages/fccanalyses/package.py
+++ b/packages/fccanalyses/package.py
@@ -9,7 +9,7 @@ class Fccanalyses(CMakePackage, Key4hepPackage):
     git = "https://github.com/HEP-FCC/FCCAnalyses.git"
     url = "https://github.com/HEP-FCC/FCCAnalyses/archive/v0.1.1.tar.gz"
 
-    maintainers = ["vvolkl", "clementhelsens", "jsmiesko"]
+    maintainers("vvolkl", "clementhelsens", "jsmiesko")
 
     version("master", branch="master")
 

--- a/packages/fccdetectors/package.py
+++ b/packages/fccdetectors/package.py
@@ -9,7 +9,7 @@ class Fccdetectors(CMakePackage, Key4hepPackage):
     url = "https://github.com/HEP-FCC/FCCDetectors/archive/refs/tags/v0.1pre03.tar.gz"
     git = "https://github.com/HEP-FCC/FCCDetectors.git"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("main", branch="main")
     # can be removed once the ci is fixed

--- a/packages/fccsw/package.py
+++ b/packages/fccsw/package.py
@@ -9,7 +9,7 @@ class Fccsw(CMakePackage, Key4hepPackage):
     url = "https://github.com/HEP-FCC/FCCSW/archive/v0.16.tar.gz"
     git = "https://github.com/HEP-FCC/FCCSW.git"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="master")
 

--- a/packages/forwardtracking/package.py
+++ b/packages/forwardtracking/package.py
@@ -14,7 +14,7 @@ class Forwardtracking(CMakePackage, Ilcsoftpackage):
     homepage = "https://github.com/iLCSoft/ForwardTracking"
     git = "https://github.com/iLCSoft/ForwardTracking.git"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="master")
     version(

--- a/packages/garlic/package.py
+++ b/packages/garlic/package.py
@@ -14,7 +14,7 @@ class Garlic(CMakePackage, Ilcsoftpackage):
     homepage = "https://github.com/iLCSoft/Garlic"
     git = "https://github.com/iLCSoft/Garlic.git"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="master")
     version(

--- a/packages/gear/package.py
+++ b/packages/gear/package.py
@@ -14,7 +14,7 @@ class Gear(CMakePackage, Ilcsoftpackage):
     git = "https://github.com/iLCSoft/gear.git"
     url = "https://github.com/iLCSoft/gear/archive/v01-05.tar.gz"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="master")
 

--- a/packages/generalbrokenlines/package.py
+++ b/packages/generalbrokenlines/package.py
@@ -15,7 +15,7 @@ class Generalbrokenlines(CMakePackage):
 
     tags = ["hep"]
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="master")
     version(

--- a/packages/guinea-pig/package.py
+++ b/packages/guinea-pig/package.py
@@ -16,7 +16,7 @@ class GuineaPig(CMakePackage):
 
     tags = ["hep"]
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="master")
     version(

--- a/packages/ilcutil/package.py
+++ b/packages/ilcutil/package.py
@@ -14,7 +14,7 @@ class Ilcutil(CMakePackage, Ilcsoftpackage):
     git = "https://github.com/iLCSoft/ilcutil.git"
     url = "https://github.com/iLCSoft/ilcutil/archive/v01-06.tar.gz"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="master")
     version(

--- a/packages/ildperformance/package.py
+++ b/packages/ildperformance/package.py
@@ -14,7 +14,7 @@ class Ildperformance(CMakePackage, Ilcsoftpackage):
     homepage = "https://github.com/iLCSoft/ILDPerformance"
     git = "https://github.com/iLCSoft/ILDPerformance.git"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="master")
     version(

--- a/packages/k4actstracking/package.py
+++ b/packages/k4actstracking/package.py
@@ -10,7 +10,7 @@ class K4actstracking(CMakePackage, Key4hepPackage):
     # url = "https://github.com/key4hep/k4ActsTracking"
     git = "https://github.com/key4hep/k4ActsTracking.git"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("main", branch="main")
 

--- a/packages/k4clue/package.py
+++ b/packages/k4clue/package.py
@@ -14,7 +14,7 @@ class K4clue(CMakePackage, Ilcsoftpackage):
     git = "https://github.com/key4hep/k4Clue.git"
     homepage = "https://github.com/key4hep/k4Clue"
 
-    maintainers = ["jmcarcell"]
+    maintainers("jmcarcell")
 
     version("main", branch="main")
 

--- a/packages/k4edm4hep2lcioconv/package.py
+++ b/packages/k4edm4hep2lcioconv/package.py
@@ -16,7 +16,7 @@ class K4edm4hep2lcioconv(CMakePackage, Key4hepPackage):
         "https://github.com/key4hep/k4EDM4hep2LcioConv/archive/refs/tags/v00-10.tar.gz"
     )
 
-    maintainers = ["tmadlener"]
+    maintainers("tmadlener")
 
     version("main", branch="main")
     version(

--- a/packages/k4gaudipandora/package.py
+++ b/packages/k4gaudipandora/package.py
@@ -14,7 +14,7 @@ class K4gaudipandora(CMakePackage, Key4hepPackage):
     homepage = "https://github.com/key4hep/k4GaudiPandora.git"
     git = "https://github.com/key4hep/k4GaudiPandora.git"
 
-    maintainers = ["jmcarcell"]
+    maintainers("jmcarcell")
 
     version("main", branch="main")
 

--- a/packages/k4gen/package.py
+++ b/packages/k4gen/package.py
@@ -9,7 +9,7 @@ class K4gen(CMakePackage, Key4hepPackage):
     url = "https://github.com/HEP-FCC/k4Gen/archive/refs/tags/v0.1pre02.tar.gz"
     git = "https://github.com/HEP-FCC/k4Gen.git"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("main", branch="main")
     version(

--- a/packages/k4generatorsconfig/package.py
+++ b/packages/k4generatorsconfig/package.py
@@ -15,7 +15,7 @@ class K4generatorsconfig(CMakePackage):
 
     generator = "Ninja"
 
-    maintainers = ["jmcarcell"]
+    maintainers("jmcarcell")
 
     version("main", branch="main")
 

--- a/packages/k4geo/package.py
+++ b/packages/k4geo/package.py
@@ -15,7 +15,7 @@ class K4geo(CMakePackage):
 
     generator = "Ninja"
 
-    maintainers = ["jmcarcell"]
+    maintainers("jmcarcell")
 
     version("main", branch="main")
     version(

--- a/packages/k4marlinwrapper/package.py
+++ b/packages/k4marlinwrapper/package.py
@@ -14,7 +14,7 @@ class K4marlinwrapper(CMakePackage, Ilcsoftpackage):
     git = "https://github.com/key4hep/k4MarlinWrapper.git"
     url = "https://github.com/key4hep/k4MarlinWrapper/archive/v00-01.tar.gz"
 
-    maintainers = ["tmadlener", "jmcarcell"]
+    maintainers("tmadlener", "jmcarcell")
 
     version("main", branch="main")
     version(

--- a/packages/k4mljettagger/package.py
+++ b/packages/k4mljettagger/package.py
@@ -9,7 +9,7 @@ class K4mljettagger(CMakePackage, Key4hepPackage):
     git = "https://github.com/key4hep/k4MLJetTagger.git"
     # url = "https://github.com/key4hep/archive/v0.1.1.tar.gz"
 
-    maintainers = ["jmcarcell"]
+    maintainers("jmcarcell")
 
     version("main", branch="main")
 

--- a/packages/k4pandora/package.py
+++ b/packages/k4pandora/package.py
@@ -16,7 +16,7 @@ class K4pandora(CMakePackage, Key4hepPackage):
 
     tags = ["hep", "key4hep"]
 
-    maintainers = ["mirguest"]
+    maintainers("mirguest")
 
     version("master", branch="master")
 

--- a/packages/k4projecttemplate/package.py
+++ b/packages/k4projecttemplate/package.py
@@ -11,7 +11,7 @@ class K4projecttemplate(CMakePackage, Key4hepPackage):
     )
     git = "https://github.com/key4hep/k4-project-template.git"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("main", branch="main")
     version(

--- a/packages/k4reccalorimeter/package.py
+++ b/packages/k4reccalorimeter/package.py
@@ -9,7 +9,7 @@ class K4reccalorimeter(CMakePackage, Key4hepPackage):
     url = "https://github.com/HEP-FCC/k4RecCalorimeter/archive/refs/tags/v0.1.0pre04.tar.gz"
     git = "https://github.com/HEP-FCC/k4RecCalorimeter.git"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("main", branch="main")
     version(

--- a/packages/k4simdelphes/package.py
+++ b/packages/k4simdelphes/package.py
@@ -14,7 +14,7 @@ class K4simdelphes(CMakePackage, Ilcsoftpackage):
     git = "https://github.com/key4hep/k4SimDelphes.git"
     url = "https://github.com/key4hep/k4SimDelphes/archive/v00-00-01.tar.gz"
 
-    maintainers = ["vvolkl", "tmadlener"]
+    maintainers("vvolkl", "tmadlener")
 
     version("main", branch="main")
     version(

--- a/packages/k4simgeant4/package.py
+++ b/packages/k4simgeant4/package.py
@@ -9,7 +9,7 @@ class K4simgeant4(CMakePackage, Key4hepPackage):
     url = "https://github.com/key4hep/k4SimGeant4/archive/v0.1.0pre05.tar.gz"
     git = "https://github.com/key4hep/k4SimGeant4.git"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("main", branch="main")
     version("0.1.0pre15", tag="v0.1.0pre15")

--- a/packages/kaldet/package.py
+++ b/packages/kaldet/package.py
@@ -14,7 +14,7 @@ class Kaldet(CMakePackage, Ilcsoftpackage):
     url = "https://github.com/iLCSoft/KalDet/archive/v01-14-01.tar.gz"
     git = "https://github.com/iLCSoft/KalDet.git"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="master")
     version(

--- a/packages/kaltest/package.py
+++ b/packages/kaltest/package.py
@@ -14,7 +14,7 @@ class Kaltest(CMakePackage, Ilcsoftpackage):
     url = "https://github.com/iLCSoft/KalTest/archive/v02-05.tar.gz"
     git = "https://github.com/iLCSoft/KalTest.git"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="master")
     version(

--- a/packages/kitrack/package.py
+++ b/packages/kitrack/package.py
@@ -14,7 +14,7 @@ class Kitrack(CMakePackage, Ilcsoftpackage):
     homepage = "https://github.com/iLCSoft/KiTrack"
     git = "https://github.com/iLCSoft/KiTrack.git"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="master")
     version(

--- a/packages/kitrackmarlin/package.py
+++ b/packages/kitrackmarlin/package.py
@@ -14,7 +14,7 @@ class Kitrackmarlin(CMakePackage, Ilcsoftpackage):
     homepage = "https://github.com/iLCSoft/KiTrackMarlin"
     git = "https://github.com/iLCSoft/KiTrackMarlin.git"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="master")
     version(

--- a/packages/kkmcee/package.py
+++ b/packages/kkmcee/package.py
@@ -18,7 +18,7 @@ class Kkmcee(AutotoolsPackage):
 
     tags = ["hep"]
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("main", branch="FCC_release")
     version(

--- a/packages/larcontent/package.py
+++ b/packages/larcontent/package.py
@@ -15,7 +15,7 @@ class Larcontent(CMakePackage):
 
     tags = ["hep"]
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="master")
     version(

--- a/packages/lccd/package.py
+++ b/packages/lccd/package.py
@@ -14,7 +14,7 @@ class Lccd(CMakePackage, Ilcsoftpackage):
     git = "https://github.com/iLCSoft/lccd.git"
     url = "https://github.com/iLCSoft/lccd/archive/v01-05.tar.gz"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="master")
     version(

--- a/packages/lccontent/package.py
+++ b/packages/lccontent/package.py
@@ -15,7 +15,7 @@ class Lccontent(CMakePackage):
 
     tags = ["hep"]
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="master")
     version(

--- a/packages/lcfiplus/package.py
+++ b/packages/lcfiplus/package.py
@@ -14,7 +14,7 @@ class Lcfiplus(CMakePackage, Ilcsoftpackage):
     homepage = "https://github.com/lcfiplus/LCFIPlus"
     git = "https://github.com/lcfiplus/LCFIPlus.git"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="master")
     version(

--- a/packages/lcfivertex/package.py
+++ b/packages/lcfivertex/package.py
@@ -14,7 +14,7 @@ class Lcfivertex(CMakePackage, Ilcsoftpackage):
     homepage = "https://github.com/iLCSoft/LCFIVertex"
     git = "https://github.com/iLCSoft/LCFIVertex.git"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="master")
     version(

--- a/packages/lctuple/package.py
+++ b/packages/lctuple/package.py
@@ -14,7 +14,7 @@ class Lctuple(CMakePackage, Ilcsoftpackage):
     homepage = "https://github.com/iLCSoft/LCTuple"
     git = "https://github.com/iLCSoft/LCTuple.git"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="master")
     version(

--- a/packages/lich/package.py
+++ b/packages/lich/package.py
@@ -16,7 +16,7 @@ class Lich(CMakePackage, Ilcsoftpackage):
 
     tags = ["hep"]
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="master")
     version(

--- a/packages/marlin/package.py
+++ b/packages/marlin/package.py
@@ -14,7 +14,7 @@ class Marlin(CMakePackage, Ilcsoftpackage):
     git = "https://github.com/iLCSoft/marlin.git"
     url = "https://github.com/iLCSoft/marlin/archive/v01-05.tar.gz"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="master")
 

--- a/packages/marlindd4hep/package.py
+++ b/packages/marlindd4hep/package.py
@@ -14,7 +14,7 @@ class Marlindd4hep(CMakePackage, Ilcsoftpackage):
     homepage = "https://github.com/iLCSoft/MarlinDD4hep"
     git = "https://github.com/iLCSoft/MarlinDD4hep.git"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="master")
     version(

--- a/packages/marlinfastjet/package.py
+++ b/packages/marlinfastjet/package.py
@@ -14,7 +14,7 @@ class Marlinfastjet(CMakePackage, Ilcsoftpackage):
     homepage = "https://github.com/iLCSoft/MarlinFastjet"
     git = "https://github.com/iLCSoft/MarlinFastjet.git"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="master")
     version(

--- a/packages/marlinkinfit/package.py
+++ b/packages/marlinkinfit/package.py
@@ -14,7 +14,7 @@ class Marlinkinfit(CMakePackage, Ilcsoftpackage):
     homepage = "https://github.com/iLCSoft/MarlinKinfit"
     git = "https://github.com/iLCSoft/MarlinKinfit.git"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="master")
     version(

--- a/packages/marlinkinfitprocessors/package.py
+++ b/packages/marlinkinfitprocessors/package.py
@@ -14,7 +14,7 @@ class Marlinkinfitprocessors(CMakePackage, Ilcsoftpackage):
     homepage = "https://github.com/iLCSoft/MarlinKinfitProcessors"
     git = "https://github.com/iLCSoft/MarlinKinfitProcessors.git"
 
-    maintainers = ["vvolkl", "tmadlener"]
+    maintainers("vvolkl", "tmadlener")
 
     version("master", branch="master")
     version(

--- a/packages/marlinreco/package.py
+++ b/packages/marlinreco/package.py
@@ -14,7 +14,7 @@ class Marlinreco(CMakePackage, Ilcsoftpackage):
     homepage = "https://github.com/iLCSoft/MarlinReco"
     git = "https://github.com/iLCSoft/MarlinReco.git"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="master")
     version(

--- a/packages/marlintrk/package.py
+++ b/packages/marlintrk/package.py
@@ -15,7 +15,7 @@ class Marlintrk(CMakePackage, Ilcsoftpackage):
     url = "https://github.com/iLCSoft/MarlinTrk/archive/v02-08.tar.gz"
     git = "https://github.com/iLCSoft/MarlinTrk.git"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="master")
     version(

--- a/packages/marlintrkprocessors/package.py
+++ b/packages/marlintrkprocessors/package.py
@@ -14,7 +14,7 @@ class Marlintrkprocessors(CMakePackage, Ilcsoftpackage):
     homepage = "https://github.com/iLCSoft/MarlinTrkProcessors"
     git = "https://github.com/iLCSoft/MarlinTrkProcessors.git"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="master")
     version(

--- a/packages/marlinutil/package.py
+++ b/packages/marlinutil/package.py
@@ -16,7 +16,7 @@ class Marlinutil(CMakePackage, Ilcsoftpackage):
     url = "https://github.com/iLCSoft/MarlinUtil/archive/v01-15-01.tar.gz"
     git = "https://github.com/iLCSoft/MarlinUtil.git"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="master")
     version(

--- a/packages/overlay/package.py
+++ b/packages/overlay/package.py
@@ -14,7 +14,7 @@ class Overlay(CMakePackage, Ilcsoftpackage):
     homepage = "https://github.com/iLCSoft/Overlay"
     git = "https://github.com/iLCSoft/Overlay.git"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="master")
     version(

--- a/packages/pandoraanalysis/package.py
+++ b/packages/pandoraanalysis/package.py
@@ -16,7 +16,7 @@ class Pandoraanalysis(CMakePackage, Ilcsoftpackage):
 
     tags = ["hep"]
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="master")
     version(

--- a/packages/physsim/package.py
+++ b/packages/physsim/package.py
@@ -14,7 +14,7 @@ class Physsim(CMakePackage, Ilcsoftpackage):
     homepage = "https://github.com/iLCSoft/Physsim"
     git = "https://github.com/iLCSoft/Physsim.git"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     tags = ["hep"]
 

--- a/packages/py-pybdsim/package.py
+++ b/packages/py-pybdsim/package.py
@@ -15,7 +15,7 @@ class PyPybdsim(PythonPackage):
 
     tags = ["hep"]
 
-    maintainers = ["jmcarcell"]
+    maintainers("jmcarcell")
 
     version("master", branch="master")
 

--- a/packages/py-pyg4ometry/package.py
+++ b/packages/py-pyg4ometry/package.py
@@ -15,7 +15,7 @@ class PyPyg4ometry(PythonPackage):
 
     tags = ["hep"]
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="develop")
 

--- a/packages/py-pyhepmc/package.py
+++ b/packages/py-pyhepmc/package.py
@@ -15,7 +15,7 @@ class PyPyhepmc(PythonPackage):
 
     tags = ["hep"]
 
-    maintainers = ["jmcarcell"]
+    maintainers("jmcarcell")
 
     version("main", branch="main")
 

--- a/packages/py-pymadx/package.py
+++ b/packages/py-pymadx/package.py
@@ -15,7 +15,7 @@ class PyPymadx(PythonPackage):
 
     tags = ["hep"]
 
-    maintainers = ["jmcarcell"]
+    maintainers("jmcarcell")
 
     version("master", branch="master")
 

--- a/packages/py-pytransport/package.py
+++ b/packages/py-pytransport/package.py
@@ -15,7 +15,7 @@ class PyPytransport(PythonPackage):
 
     tags = ["hep"]
 
-    maintainers = ["jmcarcell"]
+    maintainers("jmcarcell")
 
     version("master", branch="master")
 

--- a/packages/raida/package.py
+++ b/packages/raida/package.py
@@ -14,7 +14,7 @@ class Raida(CMakePackage, Ilcsoftpackage):
     git = "https://github.com/iLCSoft/raida.git"
     url = "https://github.com/iLCSoft/raida/archive/v01-06.tar.gz"
 
-    maintainers = ["vvolkl"]
+    maintainers("vvolkl")
 
     version("master", branch="master")
     version(


### PR DESCRIPTION
Switch to `mainainers(...)` from `maintainers = [...]` for all packages. This has been done for central packages 2 years ago. I don't think there are plans to remove the `maintainers = [...]` way for spack, but it would make our packages more in line with the central ones.