### PR TITLE
[WIP] Make stack build on latest version of spack

### DIFF
--- a/packages/ddfastshowerml/package.py
+++ b/packages/ddfastshowerml/package.py
@@ -35,6 +35,8 @@ class Ddfastshowerml(CMakePackage, Key4hepPackage):
     depends_on("dd4hep")
     depends_on("openmpi", when="@0.1.1:")
 
+    depends_on("cxx", type="build")
+
     def cmake_args(self):
         args = [
             f"-DCMAKE_CXX_STANDARD={self.spec['root'].variants['cxxstd'].value}",

--- a/packages/key4hep-stack/package.py
+++ b/packages/key4hep-stack/package.py
@@ -139,6 +139,10 @@ class Key4hepStack(BundlePackage, Key4hepPackage):
     depends_on("py-xgboost", when="+devtools")
     depends_on("benchmark", when="+devtools")
 
+    depends_on("cxx", type="build")
+    depends_on("c", type="build")
+    depends_on("fortran", type="build")
+
     def setup_run_environment(self, env):
         # set locale to avoid certain issues with xerces-c
         # (see https://github.com/key4hep/key4hep-spack/issues/170)
@@ -153,8 +157,8 @@ class Key4hepStack(BundlePackage, Key4hepPackage):
 
         # Issue on ubuntu, whizard fails to load libomega.so.0
         if (
-            self.compiler.operating_system == "ubuntu22.04"
-            or self.compiler.operating_system == "ubuntu24.04"
+            self.spec.architecture.os == "ubuntu22.04"
+            or self.spec.architecture.os == "ubuntu24.04"
         ):
             env.prepend_path(
                 "LD_LIBRARY_PATH", self.spec["whizard"].libs.directories[0]


### PR DESCRIPTION
This is a (probably incomplete) list of changes I needed to build the key4hep-spack on top of https://github.com/spack/spack/commit/5879724a2ac1d5c4ed1ccbff2b33e019b5bef4df

I am not entirely sure if these already work on the current `.latest-commit`. My suspicion would be no, as the compilers are not yet considered as nodes there, I think.