### PR TITLE
Migrate DDML from DESY gitlab to github

### DIFF
--- a/environments/key4hep-common-dbg/packages.yaml
+++ b/environments/key4hep-common-dbg/packages.yaml
@@ -15,7 +15,7 @@ packages:
     require: build_type=Debug
   dd4hep:
     require: build_type=Debug
-  ddfastshowerml:
+  ddml:
     require: build_type=Debug
   ddkaltest:
     require: build_type=Debug

--- a/environments/key4hep-common-opt/packages.yaml
+++ b/environments/key4hep-common-opt/packages.yaml
@@ -15,7 +15,7 @@ packages:
     require: build_type=Release
   dd4hep:
     require: build_type=Release
-  ddfastshowerml:
+  ddml:
     require: build_type=Release
   ddkaltest:
     require: build_type=Release

--- a/environments/key4hep-nightly-macos/packages.yaml
+++ b/environments/key4hep-nightly-macos/packages.yaml
@@ -17,7 +17,7 @@ packages:
     variants: build_type=RelWithDebInfo
   dd4hep:
     variants: build_type=RelWithDebInfo
-  ddfastshowerml:
+  ddml:
     variants: build_type=RelWithDebInfo
   ddkaltest:
     variants: build_type=RelWithDebInfo

--- a/packages/ddfastshowerml/package.py
+++ b/packages/ddfastshowerml/package.py
@@ -10,24 +10,24 @@ from spack.pkg.k4.key4hep_stack import Key4hepPackage
 class Ddfastshowerml(CMakePackage, Key4hepPackage):
     """Package with utilities and plugins that allow to run fast simulation in Geant4 from ML inference within ddsim (DDG4)"""
 
-    homepage = "https://gitlab.desy.de/ilcsoft/ddfastshowerml"
-    git = "https://gitlab.desy.de/ilcsoft/ddfastshowerml.git"
-    url = "https://gitlab.desy.de/ilcsoft/ddfastshowerml/-/archive/v0.1.0/ddfastshowerml-v0.1.0.tar.gz"
+    homepage = "https://github.com/key4hep/DDML"
+    git = "https://github.com/key4hep/DDML.git"
+    url = "https://github.com/key4hep/DDML/archive/refs/tags/v0.2.0.tar.gz"
 
     maintainers("jmcarcell", "tmadlener")
 
     version("main", branch="main")
     version(
         "0.2.0",
-        sha256="1a124c9d19efe1a5435f8838a31c4d9325e23d0bab7d46603f3de654a4cfbbfd",
+        sha256="377f34a341bcd11a177195b795c763c98f06450445839982c96adee76f51ad08",
     )
     version(
         "0.1.1",
-        sha256="a9628624736baea4261950615b698c9389763c18953c29bb5b1635d8d2dd9c3b",
+        sha256="0c11f84a912c89404de46df9ed6f0f0bb4f8985a292f0400f1c4f1b0afea1f72",
     )
     version(
         "0.1.0",
-        sha256="a9628624736baea4261950615b698c9389763c18953c29bb5b1635d8d2dd9c3b",
+        sha256="17ccdd7673780bbe91d98fe6ad3d9c2ad21803ca71b75b740a6beb0f8ea39358",
     )
 
     variant("inference", values=("onnxruntime", "torch", "both"), default="both")

--- a/packages/ddml/package.py
+++ b/packages/ddml/package.py
@@ -7,7 +7,7 @@ from spack.package import *
 from spack.pkg.k4.key4hep_stack import Key4hepPackage
 
 
-class Ddfastshowerml(CMakePackage, Key4hepPackage):
+class Ddml(CMakePackage, Key4hepPackage):
     """Package with utilities and plugins that allow to run fast simulation in Geant4 from ML inference within ddsim (DDG4)"""
 
     homepage = "https://github.com/key4hep/DDML"

--- a/packages/ilcsoft/package.py
+++ b/packages/ilcsoft/package.py
@@ -49,7 +49,7 @@ class Ilcsoft(BundlePackage, Key4hepPackage):
     depends_on("clicperformance")
     depends_on("clupatra")
     depends_on("conformaltracking")
-    depends_on("ddfastshowerml")
+    depends_on("ddml")
     depends_on("ddkaltest")
     depends_on("ddmarlinpandora")
     depends_on("fcalclusterer")

--- a/scripts/fetch_nightly_versions.py
+++ b/scripts/fetch_nightly_versions.py
@@ -116,7 +116,7 @@ if __name__ == "__main__":
         ("clicperformance", "ilcsoft/clicperformance"),
         ("conformaltracking", "ilcsoft/conformaltracking"),
         ("dd4hep", "aidasoft/dd4hep"),
-        ("ddfastshowerml", "ilcsoft/ddfastshowerml"),
+        ("ddml", "key4hep/ddml"),
         ("ddkaltest", "ilcsoft/ddkaltest"),
         ("ddmarlinpandora", "ilcsoft/ddmarlinpandora"),
         ("delphes", "delphes/delphes"),
@@ -177,7 +177,7 @@ if __name__ == "__main__":
         gitlab = False
         if package == "opendatadetector":
             gitlab = "https://gitlab.cern.ch/api/v4/projects/%s/repository/commits"
-        elif package == "ddfastshowerml" or package == "marlinmlflavortagging":
+        elif package == "marlinmlflavortagging":
             gitlab = "https://gitlab.desy.de/api/v4/projects/%s/repository/commits"
         commit = get_latest_commit(package, location, date=date, gitlab=gitlab)
         line = f"@{commit}"


### PR DESCRIPTION
BEGINRELEASENOTES
- Migrate the DDML (DDFastShowerML) library from the DESY gitlab instance to a Key4hep repository

ENDRELEASENOTES

Needs updated URLs and checksums

- [x] Do we also want to rename the spack package?
