### PR TITLE
Add a dependency on alpaka for k4Clue

### DIFF
--- a/packages/k4clue/package.py
+++ b/packages/k4clue/package.py
@@ -45,6 +45,9 @@ class K4clue(CMakePackage, Ilcsoftpackage):
     depends_on("dd4hep")
     depends_on("k4fwcore")
 
+    # Fix the range when a new version is available
+    depends_on("alpaka", when="@01-00-07:")
+
     depends_on("marlindd4hep", type="test")
     depends_on("kaltest", type="test")
     depends_on("conformaltracking", type="test")


### PR DESCRIPTION
For https://github.com/key4hep/k4Clue/pull/70. `CLUEstering` will be added later, see https://github.com/cms-patatrack/CLUEstering