### PR TITLE
Unconditionally add whizard to LD_LIBRARY_PATH

### DIFF
--- a/packages/key4hep-stack/package.py
+++ b/packages/key4hep-stack/package.py
@@ -164,14 +164,8 @@ class Key4hepStack(BundlePackage, Key4hepPackage):
             # When building podio with +rntuple there are warnings constantly without this
             env.prepend_path("LD_LIBRARY_PATH", self.spec["vdt"].libs.directories[0])
 
-        # Issue on ubuntu, whizard fails to load libomega.so.0
-        if (
-            self.spec.architecture.os == "ubuntu22.04"
-            or self.spec.architecture.os == "ubuntu24.04"
-        ):
-            env.prepend_path(
-                "LD_LIBRARY_PATH", self.spec["whizard"].libs.directories[0]
-            )
+        # Otherwise whizard generated libraries will not be able to find libomega.so
+        env.prepend_path("LD_LIBRARY_PATH", self.spec["whizard"].libs.directories[0])
 
         # When changing CMAKE_INSTALL_LIBDIR to lib, everything is installed to
         # <root>/lib, instead of <root>/lib/root which is the path that is set


### PR DESCRIPTION
BEGINRELEASENOTES
- Unconditionally set the `LD_LIBRARY_PATH` for whizard instead of only for Ubuntu

ENDRELEASENOTES

After @dirkzerwas and me have scratched our heads for quite some time about an issue in the k4GeneratorsConfig CI, we think this is the simplest solution to the problem. Especially, because it's unclear to us why it works in the first place outside of the CI container.

The issue that we see is:
- Everything works for CI in Ubuntu24
- Everything works for building k4GeneratorsConfig on e.g. the NAF or lxplus (on Alma9)
- Things don't work for CI in an Alma9 container

We currently do not understand why things work on the NAF or lxplus, because we see the same environment there as in CI, and checking the libraries that whizard builds on the fly with `ldd` point out that they cannot find `libomega.so`. Nevertheless, things can run on  the NAF/lxplus, but not in CI :shrug:
