### PR TITLE
Change the location of bdsim packages to Github

### DIFF
--- a/packages/py-pybdsim/package.py
+++ b/packages/py-pybdsim/package.py
@@ -9,9 +9,9 @@ from spack.package import *
 class PyPybdsim(PythonPackage):
     """Utilities for preparing and analysing BDSIM input and output as well as controlling BDSIM"""
 
-    homepage = "https://bitbucket.org/jairhul/pybdsim"
-    url = "https://bitbucket.org/jairhul/pybdsim/get/v3.6.1.tar.gz"
-    git = "https://bitbucket.org/jairhul/pybdsim.git"
+    homepage = "https://github.com/bdsim-collaboration/pybdsim"
+    url = "https://github.com/bdsim-collaboration/pybdsim/archive/v3.6.1.tar.gz"
+    git = "https://github.com/bdsim-collaboration/pybdsim.git"
 
     tags = ["hep"]
 
@@ -21,7 +21,7 @@ class PyPybdsim(PythonPackage):
 
     version(
         "3.6.1",
-        sha256="7bb7ba5d0f911dfc0115dce5b4a946743b34971836ef4112b2ede2195826cc11",
+        sha256="9308648b2745d60fe5da6c9422bbe8ea2f177f1987cd949ece01ab88b55bb339",
     )
 
     depends_on("py-setuptools", type="build")

--- a/packages/py-pymadx/package.py
+++ b/packages/py-pymadx/package.py
@@ -9,9 +9,9 @@ from spack.package import *
 class PyPymadx(PythonPackage):
     """Utilities for processing and analysing MADX output"""
 
-    homepage = "https://bitbucket.org/jairhul/pymadx"
-    url = "https://bitbucket.org/jairhul/pymadx/get/v2.2.1.tar.gz"
-    git = "https://bitbucket.org/jairhul/pymadx.git"
+    homepage = "https://github.com/bdsim-collaboration/pymadx"
+    url = "https://github.com/bdsim-collaboration/pymadx/archive/v2.2.1.tar.gz"
+    git = "https://github.com/bdsim-collaboration/pymadx.git"
 
     tags = ["hep"]
 
@@ -21,7 +21,7 @@ class PyPymadx(PythonPackage):
 
     version(
         "2.2.1",
-        sha256="e329204931de9be8b0ab88e7ba92045136165c382f8de02f0e11364671813276",
+        sha256="c4109b5b6214c50e1cc6f0ff76c38b3ea88043536a9c3f8b45685b8b3babac97",
     )
 
     depends_on("py-setuptools", type="build")

--- a/packages/py-pytransport/package.py
+++ b/packages/py-pytransport/package.py
@@ -9,9 +9,9 @@ from spack.package import *
 class PyPytransport(PythonPackage):
     """A Python based converter for TRANSPORT files to BDSIM readable gmad files"""
 
-    homepage = "https://bitbucket.org/jairhul/pytransport"
-    url = "https://bitbucket.org/jairhul/pytransport/get/v2.0.2.tar.gz"
-    git = "https://bitbucket.org/jairhul/pytransport.git"
+    homepage = "https://github.com/bdsim-collaboration/pytransport"
+    url = "https://github.com/bdsim-collaboration/pytransport/archive/v2.0.2.tar.gz"
+    git = "https://github.com/bdsim-collaboration/pytransport.git"
 
     tags = ["hep"]
 
@@ -21,7 +21,7 @@ class PyPytransport(PythonPackage):
 
     version(
         "2.0.2",
-        sha256="61b2c6dd6d0a682a3499a396114c9f6815513f7d4e737a6c67e2d88f68046f00",
+        sha256="5e858ec0a73695ca8ba62f221e57ed4c5182ded125372e997918a140072b5852",
     )
 
     depends_on("py-setuptools", type="build")


### PR DESCRIPTION
They have been moved to Github, see, for example, the first link in the documentation:
https://www.pp.rhul.ac.uk/bdsim/manual/

The same needs to be done for the bdsim package.