### PR TITLE
add spack-repo-index.yaml for spack 1.0

### DIFF
--- a/spack-repo-index.yaml
+++ b/spack-repo-index.yaml
@@ -1,0 +1,4 @@
+repo_index:
+  paths:
+  - .
+


### PR DESCRIPTION
BEGINRELEASENOTES
-  add spack-repo-index.yaml which allows for git package loading in spack 1.0
ENDRELEASENOTES
