### PR TITLE
k4actstracking: only depend on `acts-dd4hep` before Acts v20

### DIFF
--- a/packages/k4actstracking/package.py
+++ b/packages/k4actstracking/package.py
@@ -19,7 +19,7 @@ class K4actstracking(CMakePackage, Key4hepPackage):
     depends_on("root")
     depends_on("edm4hep")
     depends_on("k4fwcore")
-    depends_on("acts-dd4hep")
+    depends_on("acts-dd4hep", when="^acts@:19")
 
     def cmake_args(self):
         return []


### PR DESCRIPTION
BEGINRELEASENOTES
- k4actstracking: only depend on `acts-dd4hep` before Acts v20

ENDRELEASENOTES

As of Acts v20, this is not needed anymore (https://github.com/acts-project/acts/releases/tag/v20.0.0).