### PR TITLE
Update the hash of KKMCee v5.01.00

### DIFF
--- a/.cherry-pick
+++ b/.cherry-pick
@@ -21,10 +21,10 @@ git cherry-pick d8bb37270ee2f84bbaa6432cf1aa3dbea421ec9d -X theirs --no-commit
 # root: set runtime_cxxmodules to True, remove when https://github.com/spack/spack-packages/pull/109 is merged
 git cherry-pick 75e923133f6fd458d7c2d0ab5636b0a692cf77e1 -X theirs --no-commit
 
-# ghostscript: fixes for missing DSO symbol and add X libraries, remove when https://github.com/spack/spack-packages/pull/108 is merged
+# ghostscript: fixes for missing DSO symbol and add X libraries, remove!
 git cherry-pick 73078e8832bd82347e4020513a7c30cffbf3589f -X theirs --no-commit
 
-# Add build dependencies for several packages, remove when https://github.com/spack/spack-packages/pull/107 is merged
+# Add build dependencies for several packages, remove!
 git cherry-pick 65daf31f2e89c1027c3d1ecc2c03638254ea83e2 -X theirs --no-commit
 
 # py_ruff and py_rpds_py: add a dependency on C for builds on Alma 9, remove!
@@ -33,7 +33,7 @@ git cherry-pick 32e44d69f8113e3e0ff55cdb22b057a64cf70259 -X theirs --no-commit
 # madgraph5amc: add changes to install models, remove when https://github.com/spack/spack-packages/pull/110 is merged
 git cherry-pick d30d75acefeba6c18ab2263ec879ddb68d70dd48 -X theirs --no-commit
 
-# py_onnxruntime: add new versions, patches and update the recipe, remove when https://github.com/spack/spack-packages/pull/128 is merged
+# py_onnxruntime: add new versions, patches and update the recipe, remove!
 git cherry-pick 02cbdf51cddc766219bfd0ebb19f663d58744bcb -X theirs --no-commit
 
 # py_onnx: add binutils as a dependency, remove when https://github.com/spack/spack-packages/pull/141 is merged

--- a/packages/kkmcee/package.py
+++ b/packages/kkmcee/package.py
@@ -23,7 +23,7 @@ class Kkmcee(AutotoolsPackage):
     version("main", branch="FCC_release")
     version(
         "5.01.00",
-        sha256="11d80b73d7ffc4d08769c5ce55a39a96f6ac0c5a6652d87159d3398d162bd5f1",
+        sha256="f51092d23dfa917fe9a824f9d9e166fd8b02337afa922768f8c089ff4b586678",
         url="https://lcgpackages.web.cern.ch/tarFiles/sources/MCGeneratorsTarFiles/KKMCee-5.01.00.tar.gz",
     )
     version(


### PR DESCRIPTION
the new version includes a fix when using the -s or --initialseed option, which is also now saved in the pro.input file