### PR TITLE
fix: avoid `llnl` module removal warning in spack v1.0

### DIFF
--- a/packages/key4hep-stack/common.py
+++ b/packages/key4hep-stack/common.py
@@ -9,7 +9,6 @@ from spack.user_environment import *
 import os
 
 import spack.cmd
-import llnl.util.tty as tty
 import spack.platforms
 import spack.spec
 import spack.util.environment
@@ -18,6 +17,11 @@ import spack.user_environment as uenv
 
 from spack.store import STORE
 from spack.package_base import PackageBase
+
+try:
+    import spack.llnl.util.tty as tty
+except:
+    import llnl.util.tty as tty
 
 from shlex import quote as cmd_quote
 


### PR DESCRIPTION
In spack v1.0, we get the following warning any time when `common.py` is loaded:
```
==> Warning: /opt/spack-packages/repos/key4hep-spack/packages/key4hep-stack/common.py:12: The `llnl` module will be removed in Spack v1.1
```

BEGINRELEASENOTES
- fix: avoid `llnl` module removal warning in spack v1.0

ENDRELEASENOTES
