### PR TITLE
k4fwcore: depends_on c when @:1.2; k4actstracking: depends_on c and cxx

### DIFF
--- a/packages/k4actstracking/package.py
+++ b/packages/k4actstracking/package.py
@@ -14,6 +14,9 @@ class K4actstracking(CMakePackage, Key4hepPackage):
 
     version("main", branch="main")
 
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
     depends_on("acts+dd4hep+tgeo+json")
     depends_on("gaudi")
     depends_on("root")

--- a/packages/k4fwcore/package.py
+++ b/packages/k4fwcore/package.py
@@ -37,6 +37,7 @@ class K4fwcore(CMakePackage, Ilcsoftpackage):
     version("1.0pre17", tag="v01-00pre17")
     version("1.0pre16", tag="v01-00pre16")
 
+    depends_on("c", type="build", when="@:1.2")
     depends_on("cxx", type="build")
 
     depends_on("gaudi")


### PR DESCRIPTION
The addition of explicit only `CXX` to the CMake `project` directive was only added for 1.3 and later, https://github.com/key4hep/k4FWCore/commit/6c9a9d2c126bcabb9573af3c1f70275b7a8ba1bc.

BEGINRELEASENOTES
- k4fwcore, k4actstracking: depends_on c, cxx as required

ENDRELEASENOTES
