### PR TITLE
Remove the postgres variant from root

### DIFF
--- a/environments/key4hep-common/packages.yaml
+++ b/environments/key4hep-common/packages.yaml
@@ -113,7 +113,7 @@ packages:
 
   # The version seems to be necessary, otherwise it defaults to an older version
   root:
-    require: '@6.32: +davix+fftw+gsl+math+minuit+mlp+opengl~postgres~pythia8+python+r+roofit+root7+rpath~shadow+spectrum+sqlite+ssl+tbb+tmva+tmva-cpu+unuran+vc+vdt+webgui+x+xml+xrootd cxxstd=20'
+    require: '@6.32: +davix+fftw+gsl+math+minuit+mlp+opengl~pythia8+python+r+roofit+root7+rpath~shadow+spectrum+sqlite+ssl+tbb+tmva+tmva-cpu+unuran+vc+vdt+webgui+x+xml+xrootd cxxstd=20'
   py-tensorflow:
     require: ~cuda~nccl
   k4simdelphes:

--- a/environments/key4hep-nightly-macos/packages.yaml
+++ b/environments/key4hep-nightly-macos/packages.yaml
@@ -131,6 +131,6 @@ packages:
     variants: build_type=RelWithDebInfo
   # Same as the one in key4hep-common but with a newer version
   root:
-    require: +davix+fftw+gsl+math+minuit+mlp+opengl~postgres~pythia6+pythia8+python+r+root7+roofit+rpath~shadow+sqlite+ssl+tbb+threads+tmva+unuran+vc+vdt+x+xml+xrootd cxxstd=20 @6.30.02
+    require: +davix+fftw+gsl+math+minuit+mlp+opengl~pythia6+pythia8+python+r+root7+roofit+rpath~shadow+sqlite+ssl+tbb+threads+tmva+unuran+vc+vdt+x+xml+xrootd cxxstd=20 @6.30.02
   sio:
     variants: build_type=RelWithDebInfo cxxstd=20


### PR DESCRIPTION
It's not enabled and it will only be available for root@:6.36 and will confuse the concretizer after that and force it to @:6.36
