### PR TITLE
Avoid accidentally leaking tokens into the images

### DIFF
--- a/Docker/alma9/Dockerfile-externals
+++ b/Docker/alma9/Dockerfile-externals
@@ -79,5 +79,6 @@ ENV SPACK_INSTALL_OPTS="--only-concrete --no-add --fail-fast"
 RUN source ${HOME}/setup_env.sh && \
     spack spec -NIt && \
     spack install ${SPACK_INSTALL_OPTS} && \
+    spack env deactivate && \
     spack clean -a && \
     spack mirror rm local-buildcache

--- a/Docker/alma9/Dockerfile-externals
+++ b/Docker/alma9/Dockerfile-externals
@@ -32,12 +32,12 @@ ENV SPACK_COLOR="always"
 ARG SPACK_BUILDCACHE
 ARG OCI_USERNAME
 RUN --mount=type=secret,id=ocipass \
-    OCI_PASSWORD=$(cat /run/secrets/ocipass) && \
+    export OCI_PASSWORD=$(cat /run/secrets/ocipass) && \
     source /opt/setup_spack.sh && \
     spack config add 'config:install_tree:padded_length:128' && \
     spack compiler find && \
     if [ -n "${SPACK_BUILDCACHE}" ]; then \
-        spack mirror add --oci-username "${OCI_USERNAME}" --oci-password "${OCI_PASSWORD}" --unsigned --autopush local-buildcache "${SPACK_BUILDCACHE}";\
+        spack mirror add --oci-username "${OCI_USERNAME}" --oci-password-variable OCI_PASSWORD --unsigned --autopush local-buildcache "${SPACK_BUILDCACHE}";\
     fi
 
 RUN source /opt/setup_spack.sh && \
@@ -76,7 +76,9 @@ RUN source ${HOME}/setup_env.sh && \
 # Installing fragments of dependency tree in separate layers for cached debugging
 ENV SPACK_INSTALL_OPTS="--only-concrete --no-add --fail-fast"
 
-RUN source ${HOME}/setup_env.sh && \
+RUN --mount=type=secret,id=ocipass \
+    export OCI_PASSWORD=$(cat /run/secrets/ocipass) && \
+    . ${HOME}/setup_env.sh && \
     spack spec -NIt && \
     spack install ${SPACK_INSTALL_OPTS} && \
     spack env deactivate && \

--- a/Docker/alma9/Dockerfile-externals
+++ b/Docker/alma9/Dockerfile-externals
@@ -31,9 +31,7 @@ RUN if [ -n "${SPACK_COMMIT}" ]; then \
 ENV SPACK_COLOR="always"
 ARG SPACK_BUILDCACHE
 ARG OCI_USERNAME
-RUN --mount=type=secret,id=ocipass \
-    export OCI_PASSWORD=$(cat /run/secrets/ocipass) && \
-    source /opt/setup_spack.sh && \
+RUN . /opt/setup_spack.sh && \
     spack config add 'config:install_tree:padded_length:128' && \
     spack compiler find && \
     if [ -n "${SPACK_BUILDCACHE}" ]; then \
@@ -70,17 +68,17 @@ RUN source /opt/setup_spack.sh && \
     echo "spack env status" >> ${HOME}/setup_env.sh
 
 # Concretizing the stack reusing system packages as external
-RUN source ${HOME}/setup_env.sh && \
-    spack concretize --reuse
+RUN --mount=type=secret,id=ocipass \
+    . ${HOME}/setup_env.sh && \
+    OCI_PASSWORD=$(cat /run/secrets/ocipass) spack concretize --reuse
 
 # Installing fragments of dependency tree in separate layers for cached debugging
 ENV SPACK_INSTALL_OPTS="--only-concrete --no-add --fail-fast"
 
 RUN --mount=type=secret,id=ocipass \
-    export OCI_PASSWORD=$(cat /run/secrets/ocipass) && \
     . ${HOME}/setup_env.sh && \
-    spack spec -NIt && \
-    spack install ${SPACK_INSTALL_OPTS} && \
+    OCI_PASSWORD=$(cat /run/secrets/ocipass) spack spec -NIt && \
+    OCI_PASSWORD=$(cat /run/secrets/ocipass) spack install ${SPACK_INSTALL_OPTS} && \
     spack env deactivate && \
     spack clean -a && \
     spack mirror rm local-buildcache

--- a/Docker/alma9/Dockerfile-externals
+++ b/Docker/alma9/Dockerfile-externals
@@ -79,4 +79,5 @@ ENV SPACK_INSTALL_OPTS="--only-concrete --no-add --fail-fast"
 RUN source ${HOME}/setup_env.sh && \
     spack spec -NIt && \
     spack install ${SPACK_INSTALL_OPTS} && \
-    spack clean -a
+    spack clean -a && \
+    spack mirror rm local-buildcache

--- a/Docker/ubuntu24/Dockerfile-externals
+++ b/Docker/ubuntu24/Dockerfile-externals
@@ -76,5 +76,6 @@ ENV SPACK_INSTALL_OPTS="--only-concrete --no-add --fail-fast"
 RUN . ${HOME}/setup_env.sh && \
     spack spec -NIt && \
     spack install ${SPACK_INSTALL_OPTS} && \
+    spack env deactivate && \
     spack clean -a && \
     spack mirror rm local-buildcache

--- a/Docker/ubuntu24/Dockerfile-externals
+++ b/Docker/ubuntu24/Dockerfile-externals
@@ -76,4 +76,5 @@ ENV SPACK_INSTALL_OPTS="--only-concrete --no-add --fail-fast"
 RUN . ${HOME}/setup_env.sh && \
     spack spec -NIt && \
     spack install ${SPACK_INSTALL_OPTS} && \
-    spack clean -a
+    spack clean -a && \
+    spack mirror rm local-buildcache

--- a/Docker/ubuntu24/Dockerfile-externals
+++ b/Docker/ubuntu24/Dockerfile-externals
@@ -28,9 +28,7 @@ RUN if [ -n "${SPACK_COMMIT}" ]; then \
 ENV SPACK_COLOR="always"
 ARG SPACK_BUILDCACHE
 ARG OCI_USERNAME
-RUN --mount=type=secret,id=ocipass \
-    OCI_PASSWORD=$(cat /run/secrets/ocipass) && \
-    . /opt/setup_spack.sh && \
+RUN . /opt/setup_spack.sh && \
     spack config add 'config:install_tree:padded_length:128' && \
     spack compiler find && \
     if [ -n "${SPACK_BUILDCACHE}" ]; then \
@@ -67,17 +65,17 @@ RUN . /opt/setup_spack.sh && \
     echo "spack env status" >> ${HOME}/setup_env.sh
 
 # Concretizing the stack reusing system packages as external
-RUN . ${HOME}/setup_env.sh && \
-    spack concretize --reuse
+RUN --mount=type=secret,id=ocipass \
+    . ${HOME}/setup_env.sh && \
+    OCI_PASSWORD=$(cat /run/secrets/ocipass) spack concretize --reuse
 
 # Installing fragments of dependency tree in separate layers for cached debugging
 ENV SPACK_INSTALL_OPTS="--only-concrete --no-add --fail-fast"
 
 RUN --mount=type=secret,id=ocipass \
-    export OCI_PASSWORD=$(cat /run/secrets/ocipass) && \
    . ${HOME}/setup_env.sh && \
-    spack spec -NIt && \
-    spack install ${SPACK_INSTALL_OPTS} && \
+    OCI_PASSWORD=$(cat /run/secrets/ocipass) spack spec -NIt && \
+    OCI_PASSWORD=$(cat /run/secrets/ocipass) spack install ${SPACK_INSTALL_OPTS} && \
     spack env deactivate && \
     spack clean -a && \
     spack mirror rm local-buildcache

--- a/Docker/ubuntu24/Dockerfile-externals
+++ b/Docker/ubuntu24/Dockerfile-externals
@@ -34,7 +34,7 @@ RUN --mount=type=secret,id=ocipass \
     spack config add 'config:install_tree:padded_length:128' && \
     spack compiler find && \
     if [ -n "${SPACK_BUILDCACHE}" ]; then \
-        spack mirror add --oci-username "${OCI_USERNAME}" --oci-password "${OCI_PASSWORD}" --unsigned --autopush local-buildcache "${SPACK_BUILDCACHE}";\
+        spack mirror add --oci-username "${OCI_USERNAME}" --oci-password-variable OCI_PASSWORD --unsigned --autopush local-buildcache "${SPACK_BUILDCACHE}";\
     fi
 
 RUN . /opt/setup_spack.sh && \
@@ -73,7 +73,9 @@ RUN . ${HOME}/setup_env.sh && \
 # Installing fragments of dependency tree in separate layers for cached debugging
 ENV SPACK_INSTALL_OPTS="--only-concrete --no-add --fail-fast"
 
-RUN . ${HOME}/setup_env.sh && \
+RUN --mount=type=secret,id=ocipass \
+    export OCI_PASSWORD=$(cat /run/secrets/ocipass) && \
+   . ${HOME}/setup_env.sh && \
     spack spec -NIt && \
     spack install ${SPACK_INSTALL_OPTS} && \
     spack env deactivate && \


### PR DESCRIPTION
Tokens are stored in plaintext in spack configuration files and can be extracted from there, e.g. via

`spack config blame mirrors`


BEGINRELEASENOTES
- Avoid leaking github tokens into the images that are created. **The leaked tokens are revoked by github after a workflow finishes or after a maximum of 24 hours, so leaked tokens cannot be used!**

ENDRELEASENOTES

https://docs.github.com/en/actions/concepts/security/github_token for source of token lifetime