### PR TITLE
Tag images as latest only from "main"

### DIFF
--- a/.github/workflows/image-template.yaml
+++ b/.github/workflows/image-template.yaml
@@ -53,7 +53,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ inputs.registry }}/${{ github.repository_owner }}/key4hep-externals-${{ inputs.os }}
-          flavor: latest=true
+          flavor: latest=${{ github.ref == 'refs/heads/main' }}
       - name: Create manifest
         id: build
         uses: int128/docker-manifest-create-action@v2


### PR DESCRIPTION
BEGINRELEASENOTES
- Docker images are tagged as latest only when they are build from the main branch
ENDRELEASENOTES
