### PR TITLE
Depend on autoconf, automake and libtool to make sure they are in PATH

### DIFF
--- a/packages/key4hep-stack/package.py
+++ b/packages/key4hep-stack/package.py
@@ -91,11 +91,14 @@ class Key4hepStack(BundlePackage, Key4hepPackage):
     depends_on("py-pytransport", when="+generators")
 
     # Devtools
+    depends_on("autoconf", when="+devtools")
+    depends_on("automake", when="+devtools")
     depends_on("catch2@3:", when="+devtools")
     depends_on("cmake", when="+devtools")
     depends_on("cppcheck", when="+devtools")
     depends_on("doxygen", when="+devtools")
     depends_on("gdb", when="+devtools")
+    depends_on("libtool", when="+devtools")
     depends_on("llvm", when="+devtools")
     # depends_on("iwyu", when="+devtools") # Not that useful and makes the LLVM built be older than it should
     depends_on("man-db", when="+devtools")


### PR DESCRIPTION
Needed because in Spack I think these are treated differently now since they are
part of a build system. Without this, they are not in the spec and then they will not be in PATH.