### PR TITLE
Enable prmon as part of devtools

### DIFF
--- a/packages/key4hep-stack/package.py
+++ b/packages/key4hep-stack/package.py
@@ -104,7 +104,7 @@ class Key4hepStack(BundlePackage, Key4hepPackage):
     depends_on("man-db", when="+devtools")
     depends_on("mold", when="+devtools")
     depends_on("ninja", when="+devtools")
-    # depends_on('prmon', when='+devtools')
+    depends_on("prmon", when="+devtools")
     depends_on("py-awkward", when="+devtools")
     depends_on("py-black", when="+devtools")
     depends_on("py-flake8", when="+devtools")


### PR DESCRIPTION
BEGINRELEASENOTES
- Enable prmon as part of the `+devtools` variant

ENDRELEASENOTES

Mainly because we just wanted to use it and had to build it manually on top of the nightlies.
