### PR TITLE
Temporarily disable marlinmlflavortagging in the nightlies

### DIFF
--- a/scripts/fetch_nightly_versions.py
+++ b/scripts/fetch_nightly_versions.py
@@ -185,6 +185,7 @@ if __name__ == "__main__":
         if package == "opendatadetector":
             gitlab = "https://gitlab.cern.ch/api/v4/projects/%s/repository/commits"
         elif package == "marlinmlflavortagging":
+            continue
             gitlab = "https://gitlab.desy.de/api/v4/projects/%s/repository/commits"
         try:
             commit = get_latest_commit(package, location, date=date, gitlab=gitlab)


### PR DESCRIPTION
since cloning from gitlab.desy.de at CERN nodes doesn't seem to work.