### PR TITLE
Remove build/usage of fccdetectors package

### DIFF
--- a/environments/key4hep-common-dbg/packages.yaml
+++ b/environments/key4hep-common-dbg/packages.yaml
@@ -29,8 +29,6 @@ packages:
     require: build_type=Debug
   fccanalyses:
     require: build_type=Debug
-  fccdetectors:
-    require: build_type=Debug
   forwardtracking:
     require: build_type=Debug
   gaudi:

--- a/environments/key4hep-common-opt/packages.yaml
+++ b/environments/key4hep-common-opt/packages.yaml
@@ -29,8 +29,6 @@ packages:
     require: +ipo build_type=Release
   fccanalyses:
     require: +ipo build_type=Release
-  fccdetectors:
-    require: +ipo build_type=Release
   forwardtracking:
     require: +ipo build_type=Release
   gaudi:

--- a/environments/key4hep-nightly-macos/packages.yaml
+++ b/environments/key4hep-nightly-macos/packages.yaml
@@ -31,8 +31,6 @@ packages:
     variants: build_type=RelWithDebInfo cxxstd=20
   fccanalyses:
     variants: build_type=RelWithDebInfo cxxstd=20
-  fccdetectors:
-    variants: build_type=RelWithDebInfo cxxstd=20
   fccsw:
     variants: build_type=RelWithDebInfo cxxstd=20
   forwardtracking:

--- a/packages/fccsw/package.py
+++ b/packages/fccsw/package.py
@@ -39,7 +39,6 @@ class Fccsw(CMakePackage, Key4hepPackage):
     depends_on("k4fwcore", type="test")
     depends_on("k4gen", type="test")
     depends_on("k4simdelphes", type="test")
-    depends_on("fccdetectors", type="test")
     depends_on("k4simgeant4", type="test")
     depends_on("k4reccalorimeter", type="test")
     depends_on("k4geo", type="test")

--- a/packages/k4simgeant4/package.py
+++ b/packages/k4simgeant4/package.py
@@ -47,7 +47,6 @@ class K4simgeant4(CMakePackage, Key4hepPackage):
     depends_on("g4ensdfstate")
     depends_on("root")
 
-    depends_on("fccdetectors", type="test")
     depends_on("k4gen", type="test")
 
     def cmake_args(self):

--- a/packages/key4hep-stack/package.py
+++ b/packages/key4hep-stack/package.py
@@ -89,7 +89,6 @@ class Key4hepStack(BundlePackage, Key4hepPackage):
     depends_on("fccanalyses~onnx", when="~ml~full")
     depends_on("fccanalyses+onnx", when="+ml")
     depends_on("fccanalyses+onnx", when="+full")
-    depends_on("fccdetectors")
     depends_on("k4reccalorimeter", when="+ml")
     depends_on("k4reccalorimeter", when="+full")
 

--- a/scripts/fetch_nightly_versions.py
+++ b/scripts/fetch_nightly_versions.py
@@ -131,7 +131,6 @@ if __name__ == "__main__":
         ("fcalclusterer", "fcalsw/fcalclusterer"),
         ("fccanalyses", "hep-fcc/fccanalyses"),
         ("fcc-config", "hep-fcc/fcc-config"),
-        ("fccdetectors", "hep-fcc/fccdetectors"),
         ("fccsw", "hep-fcc/fccsw"),
         ("forwardtracking", "ilcsoft/forwardtracking"),
         ("gear", "ilcsoft/gear"),


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove build/usage of fccdetectors package
ENDRELEASENOTES

propose to remove the fccdetectors package as geometries have been migrated to k4geo. This PR depends on https://github.com/key4hep/k4SimGeant4/pull/95 