### PR TITLE
Make the setup scripts safe to source with set -u

### DIFF
--- a/packages/key4hep-stack/common.py
+++ b/packages/key4hep-stack/common.py
@@ -101,8 +101,12 @@ def k4_generate_setup_script(env_mod, shell="sh"):
     k4_shell_set_strings = {
         "sh": "export {0}={1}\n",
     }
+    # ${VAR:-} rather than $VAR so that the generated script can be sourced from
+    # a shell running with `set -u`, where expanding an unset variable is fatal.
+    # The expansion is identical when the variable is set, and both forms expand
+    # to the empty string when it is not, so the generated environment is unchanged.
     k4_shell_prepend_strings = {
-        "sh": "export {0}={1}:${0}\n",
+        "sh": "export {0}={1}:${{{0}:-}}\n",
     }
     cmds = []
     for name in set(new_env):

--- a/scripts/cvmfs/setup-nightlies.sh
+++ b/scripts/cvmfs/setup-nightlies.sh
@@ -192,7 +192,7 @@ lcg_setup=0
 
 for ((i=1; i<=$#; i++)); do
     eval arg=\$$i
-    eval "argn=\${$((i+1))}"
+    eval "argn=\${$((i+1)):-}"
     case $arg in
         --lcg)
             lcg_setup=1
@@ -247,7 +247,7 @@ if [ $lcg_setup -eq 1 ]; then
         return 1
     fi
 
-    if [ -n "$KEY4HEP_STACK" ]; then
+    if [ -n "${KEY4HEP_STACK:-}" ]; then
         echo "The Key4hep software stack is already set up, please start a new shell to avoid conflicts"
         return 1
     fi
@@ -275,18 +275,18 @@ if [ $lcg_setup -eq 1 ]; then
 fi
 
 rel="latest-$build_type"
-if [[ "$1" = "-r" && -n "$2" ]]; then
+if [[ "${1:-}" = "-r" && -n "${2:-}" ]]; then
     rel="$2"
 fi
 
-check_release $1 $2 $os
+check_release "${1:-}" "${2:-}" "$os"
 if [ $? -ne 0 ]; then
   return 1
 fi
 
 for ((i=1; i<=$#; i++)); do
     eval arg=\$$i
-    eval "argn=\${$((i+1))}"
+    eval "argn=\${$((i+1)):-}"
     case $arg in
         --help|-h)
             usage
@@ -366,9 +366,9 @@ if [ "$(echo $rel | grep -E '^2024-09-[0-9]{2}$')" ] && [ "$(date -d $rel +%s)" 
 fi
 
 
-k4path=$(/usr/bin/ls -rd /cvmfs/sw-nightlies.hsf.org/key4hep/releases/$rel/*$os*$compiler*$build_type | head -n1)
+k4path=$(/usr/bin/ls -rd /cvmfs/sw-nightlies.hsf.org/key4hep/releases/$rel/*$os*${compiler:-}*$build_type | head -n1)
 
-if [ -n "$KEY4HEP_STACK" ]; then
+if [ -n "${KEY4HEP_STACK:-}" ]; then
     echo "The Key4hep software stack is already set up, please start a new shell to avoid conflicts"
     return 1
 fi
@@ -385,7 +385,7 @@ setup_actual=$(readlink -f $setup_script_path)
 export key4hep_stack_version=$(echo "$setup_actual"| grep -Po '(?<=key4hep-stack/)(.*)(?=-[[:alnum:]]{6}/)')
 
 # For SWAN
-if [ -n "$LCG_VERSION" ]; then
+if [ -n "${LCG_VERSION:-}" ]; then
     echo "A LCG stack has been sourced, unsetting the following variables to avoid conflicts:"
     echo "CMAKE_PREFIX_PATH CPPYY_BACKEND_LIBRARY LD_LIBRARY_PATH PKG_CONFIG_PATH PYTHONHOME PYTHONPATH"
     unset CMAKE_PREFIX_PATH CPPYY_BACKEND_LIBRARY LD_LIBRARY_PATH PKG_CONFIG_PATH PYTHONHOME PYTHONPATH

--- a/scripts/cvmfs/setup-releases.sh
+++ b/scripts/cvmfs/setup-releases.sh
@@ -178,7 +178,7 @@ k4_local_repo() {
 build_type=opt
 for ((i=1; i<=$#; i++)); do
     eval arg=\$$i
-    eval "argn=\${$((i+1))}"
+    eval "argn=\${$((i+1)):-}"
     case $arg in
         -d)
             build_type=dbg
@@ -192,7 +192,7 @@ done
 
 
 rel="latest-$build_type"
-if [[ "$1" = "-r" && -n "$2" ]]; then
+if [[ "${1:-}" = "-r" && -n "${2:-}" ]]; then
     rel="$2"
 fi
 
@@ -220,14 +220,14 @@ else
     return 1
 fi
 
-check_release $1 $2 $os
+check_release "${1:-}" "${2:-}" "$os"
 if [ $? -ne 0 ]; then
   return 1
 fi
 
 for ((i=1; i<=$#; i++)); do
     eval arg=\$$i
-    eval "argn=\${$((i+1))}"
+    eval "argn=\${$((i+1)):-}"
     case $arg in
         --help|-h)
             usage
@@ -274,9 +274,9 @@ for ((i=1; i<=$#; i++)); do
     esac
 done
 
-k4path=$(/usr/bin/ls -rd /cvmfs/sw.hsf.org/key4hep/releases/$rel/*$os*$compiler*$build_type | head -n1)
+k4path=$(/usr/bin/ls -rd /cvmfs/sw.hsf.org/key4hep/releases/$rel/*$os*${compiler:-}*$build_type | head -n1)
 
-if [ -n "$KEY4HEP_STACK" ]; then
+if [ -n "${KEY4HEP_STACK:-}" ]; then
     echo "The Key4hep software stack is already set up, please start a new shell to avoid conflicts"
     return 1
 fi
@@ -300,7 +300,7 @@ setup_actual=$(readlink -f $setup_script_path)
 export key4hep_stack_version=$(echo "$setup_actual"| grep -Po '(?<=key4hep-stack/)(.*)(?=-[[:alnum:]]{6}/)')
 
 # For SWAN
-if [ -n "$LCG_VERSION" ]; then
+if [ -n "${LCG_VERSION:-}" ]; then
     echo "A LCG stack has been sourced, unsetting the following variables to avoid conflicts:"
     echo "CMAKE_PREFIX_PATH CPPYY_BACKEND_LIBRARY LD_LIBRARY_PATH PKG_CONFIG_PATH PYTHONHOME PYTHONPATH"
     unset CMAKE_PREFIX_PATH CPPYY_BACKEND_LIBRARY LD_LIBRARY_PATH PKG_CONFIG_PATH PYTHONHOME PYTHONPATH


### PR DESCRIPTION
Sourcing the Key4hep stack from a script running with `set -u` (e.g. `set -euo pipefail`, common in batch and CI job scripts) currently aborts with an unbound variable error.

### Reproducer

```console
$ bash -c 'set -u; source /cvmfs/sw.hsf.org/key4hep/setup.sh'
/cvmfs/sw.hsf.org/key4hep/setup.sh: line 195: $1: unbound variable

$ bash -c 'set -u; source /cvmfs/sw.hsf.org/key4hep/setup.sh -d'
/cvmfs/sw.hsf.org/key4hep/setup.sh: line 181: 2: unbound variable
```

There are two independent causes.

#### 1. Positional parameters in the CVMFS setup scripts

`setup-releases.sh` / `setup-nightlies.sh` dereference `$1`/`$2` unguarded, and `eval "argn=\${$((i+1))}"` reads one past the last argument (so it fires whenever any argument is passed).

`check_release $1 $2 $os` was also unquoted: with no arguments the empty words collapse and `$os` is passed as the function's *first* parameter rather than its third.

#### 2. The generated stack setup.sh

After fixing (1), sourcing still fails, this time inside the script written by `k4_generate_setup_script()`:

```console
.../key4hep-stack/2026-04-08-i6h4f2/setup.sh: line 1: ACLOCAL_PATH: unbound variable
```

The prepend template emits `export VAR=...:$VAR`. Using `${VAR:-}` expands identically when the variable is set, and both forms expand to the empty string when it is not, so the generated environment is unchanged.

### Testing

Against the `2026-04-08` release on `/cvmfs/sw.hsf.org`, AlmaLinux 9:

| case | before | after |
| --- | --- | --- |
| `set -u`, no arguments | fail | pass |
| `set -u`, `-d` | fail | pass |
| `set -u`, `-r 2026-04-08` | fail | pass |
| `set -euo pipefail` | fail | pass |
| `--list-releases`, `-h` | pass | pass |
| no `set -u` (default usage) | pass | pass |

Applying the generator change to the already-deployed generated script rewrote 21 lines; it then sourced cleanly under `set -u` (239 `PATH` entries), whereas the original fails on line 1.

Behaviour without `set -u` is unaffected. `black` and the pre-commit hooks pass, and both shell scripts pass `bash -n`.