### PR TITLE
Add GCC 16 support for LCG nightlies

### DIFF
--- a/scripts/cvmfs/setup-nightlies.sh
+++ b/scripts/cvmfs/setup-nightlies.sh
@@ -4,10 +4,10 @@
 
 function usage() {
     echo "Usage: source /cvmfs/sw-nightlies.hsf.org/key4hep/setup.sh [--lcg] [-c <compiler>] [-r <release>] [-d] [--list-releases [distribution]] [--list-packages [distribution]]"
-    # echo "       -c           : select compiler, gcc14 (default) on AlmaLinux 9, system for the other OSes"
+    echo "       -c <compiler> : select the compiler (for --lcg on AlmaLinux 9: gcc16 (default) or gcc14)"
     echo "       -d           : setup the debug version of the software stack"
     echo "       -r <release> : setup a specific release, if not specified the latest release will be used (also used for --list-packages)"
-    echo "       --lcg        : source the LCG devkey-head view from CVMFS (only compatible with -d)"
+    echo "       --lcg        : source the LCG devkey-head view from CVMFS"
     echo "       --help, -h   : print this help message"
     echo "       --list-releases [distribution] : list available releases for the specified distribution (almalinux, centos, ubuntu). By default (no OS is specified) it will list the releases for the detected distribution (not supported for Ubuntu 26)"
     echo "       --list-packages [distribution] : list available packages and their versions for the specified distribution (almalinux, centos, ubuntu). By default (no OS is specified) it will list the packages for the detected distribution (not supported for Ubuntu 26)"
@@ -227,13 +227,26 @@ if [ "$os" = "ubuntu26" ]; then
 fi
 
 if [ $lcg_setup -eq 1 ]; then
+    lcg_compiler_request=""
     if [ "$os" != "ubuntu26" ]; then
-        for arg in "$@"; do
+        for ((i=1; i<=$#; i++)); do
+            eval arg=\$$i
+            eval "argn=\${$((i+1)):-}"
             case "$arg" in
                 --lcg|-d)
                     ;;
+                -c)
+                    if [ "$argn" = "gcc14" ] || [ "$argn" = "gcc16" ]; then
+                        lcg_compiler_request="$argn"
+                        ((i++))
+                    else
+                        echo "Unsupported compiler ${argn:-<none>} for --lcg, aborting..."
+                        usage
+                        return 1
+                    fi
+                    ;;
                 *)
-                    echo "The --lcg option is only compatible with -d"
+                    echo "The --lcg option is only compatible with -d and -c gcc14|gcc16"
                     usage
                     return 1
                     ;;
@@ -261,7 +274,7 @@ if [ $lcg_setup -eq 1 ]; then
         lcg_compiler_tag="gcc15"
     else
         lcg_os_tag="el9"
-        lcg_compiler_tag="gcc14"
+        lcg_compiler_tag="${lcg_compiler_request:-gcc16}"
     fi
     lcg_setup_script="/cvmfs/sft-nightlies.cern.ch/lcg/views/devkey-head/latest/${lcg_arch_tag}-${lcg_os_tag}-${lcg_compiler_tag}-${build_type}/setup.sh"
     if [ ! -f "$lcg_setup_script" ]; then


### PR DESCRIPTION
Add support for GCC 16 (with C++23) and make it the default when using LCG stacks.