### PR TITLE
k4clue: Change k4clue to inherit from Key4hepPackage instead of ILCsoftpackage

### DIFF
--- a/packages/k4clue/package.py
+++ b/packages/k4clue/package.py
@@ -4,10 +4,10 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
-from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
+from spack.pkg.k4.key4hep_stack import Key4hepPackage
 
 
-class K4clue(CMakePackage, Ilcsoftpackage):
+class K4clue(CMakePackage, Key4hepPackage):
     """CLUE Clustering for Key4hep"""
 
     url = "https://github.com/key4hep/k4Clue/archive/v01-00-01.tar.gz"


### PR DESCRIPTION
This is a very minor change; I noticed that the the k4clue package inherits from ILCsoftpackage. Unfortunately this causes installing `k4clue@main` to fail, because the ILCsoft package class apparently expects the version to be formatted in the XX-YY-ZZ format. I was able to fix this by changing to use the key4hep package class instead, as is done in this commit.