### PR TITLE
Make sure that spack can still deal with development versions

### DIFF
--- a/packages/generalbrokenlines/package.py
+++ b/packages/generalbrokenlines/package.py
@@ -63,6 +63,10 @@ class Generalbrokenlines(CMakePackage):
         # the patch version is omitted when 0
         # so for example v01-12-01, v01-12 ...
         base_url = self.url.rsplit("/", 1)[0]
+
+        if version.isdevelop():
+            return f"{base_url}/refs/heads/{version}.tar.gz"
+
         major = str(version[0]).zfill(2)
         minor = str(version[1]).zfill(2)
         # handle the different cases for the patch version:

--- a/packages/key4hep-stack/common.py
+++ b/packages/key4hep-stack/common.py
@@ -128,6 +128,15 @@ def ilc_url_for_version(self, version):
     :type param: str
     """
     base_url = self.url.rsplit("/", 1)[0]
+
+    if version.isdevelop():
+        return f"{base_url}/refs/heads/{version}.tar.gz"
+
+    if len(version) > 3:
+        # pre-releases are not separated from the release version,
+        # e.g. 1.0pre19 -> v01-00pre19
+        return f"{base_url}/v{version[0]:02d}-{version[1]:02d}{version[2:]}.tar.gz"
+
     if len(version) == 1:
         major = version[0]
         minor, patch = 0, 0

--- a/packages/kkmcee/package.py
+++ b/packages/kkmcee/package.py
@@ -190,5 +190,12 @@ class Kkmcee(AutotoolsPackage):
     def url_for_version(self, version):
         # contrary to ilcsoftpackages, here the patch version is kept when 0
         base_url = self.url[: self.url.rfind("/")]
+
+        if version.isdevelop():
+            # the develop version does not follow the release naming, and the
+            # branch name differs from the version name
+            branch = self.versions.get(version, {}).get("branch", str(version))
+            return self.url.rsplit("/refs/", 1)[0] + f"/refs/heads/{branch}.tar.gz"
+
         url = base_url + "/v%s.tar.gz" % (version)
         return url

--- a/packages/larcontent/package.py
+++ b/packages/larcontent/package.py
@@ -64,6 +64,10 @@ class Larcontent(CMakePackage):
     def url_for_version(self, version):
         # contrary to ilcsoftpackages, here the patch version is kept when 0
         base_url = self.url[: self.url.rfind("/")]
+
+        if version.isdevelop():
+            return f"{base_url}/refs/heads/{version}.tar.gz"
+
         major = str(version[0]).zfill(2)
         minor = str(version[1]).zfill(2)
         patch = str(version[2]).zfill(2)

--- a/packages/lccontent/package.py
+++ b/packages/lccontent/package.py
@@ -59,6 +59,10 @@ class Lccontent(CMakePackage):
     def url_for_version(self, version):
         # contrary to ilcsoftpackages, here the patch version is kept when 0
         base_url = self.url[: self.url.rfind("/")]
+
+        if version.isdevelop():
+            return f"{base_url}/refs/heads/{version}.tar.gz"
+
         major = str(version[0]).zfill(2)
         minor = str(version[1]).zfill(2)
         patch = str(version[2]).zfill(2)


### PR DESCRIPTION
This becomes necessary for newer spack versions which fail otherwise. Similar changes have been applied to upstream packages


BEGINRELEASENOTES
- Fix `url_from_version` to be able to deal with develop versions

ENDRELEASENOTES

Claude did its thing here.