### PR TITLE
Update PandoraPFA repository URLs

### DIFF
--- a/packages/larcontent/package.py
+++ b/packages/larcontent/package.py
@@ -9,9 +9,9 @@ from spack.package import *
 class Larcontent(CMakePackage):
     """Pandora algorithms and tools for LAr TPC event reconstruction"""
 
-    url = "https://github.com/PandoraPFA/larcontent/archive/v03_04_00.tar.gz"
-    homepage = "https://github.com/PandoraPFA/larcontent"
-    git = "https://github.com/PandoraPFA/larcontent.git"
+    url = "https://github.com/PandoraPFAOrg/larcontent/archive/v03_04_00.tar.gz"
+    homepage = "https://github.com/PandoraPFAOrg/larcontent"
+    git = "https://github.com/PandoraPFAOrg/larcontent.git"
 
     tags = ["hep"]
 

--- a/packages/lccontent/package.py
+++ b/packages/lccontent/package.py
@@ -9,9 +9,9 @@ from spack.package import *
 class Lccontent(CMakePackage):
     """Pandora algorithms and tools for Linear Collider event reconstruction."""
 
-    url = "https://github.com/PandoraPFA/lccontent/archive/v03-01-05.tar.gz"
-    homepage = "https://github.com/PandoraPFA/lccontent"
-    git = "https://github.com/PandoraPFA/lccontent.git"
+    url = "https://github.com/PandoraPFAOrg/lccontent/archive/v03-01-05.tar.gz"
+    homepage = "https://github.com/PandoraPFAOrg/lccontent"
+    git = "https://github.com/PandoraPFAOrg/lccontent.git"
 
     tags = ["hep"]
 

--- a/packages/pandoraanalysis/package.py
+++ b/packages/pandoraanalysis/package.py
@@ -10,9 +10,9 @@ from spack.pkg.k4.key4hep_stack import Ilcsoftpackage
 class Pandoraanalysis(CMakePackage, Ilcsoftpackage):
     """Pandora calibration and analysis tools in iLCSoft / Marlin framework"""
 
-    url = "https://github.com/PandoraPFA/LCPandoraAnalysis/archive/v02-00-01.tar.gz"
-    homepage = "https://github.com/PandoraPFA/LCPandoraAnalysis"
-    git = "https://github.com/PandoraPFA/LCPandoraAnalysis.git"
+    url = "https://github.com/PandoraPFAOrg/LCPandoraAnalysis/archive/v02-00-01.tar.gz"
+    homepage = "https://github.com/PandoraPFAOrg/LCPandoraAnalysis"
+    git = "https://github.com/PandoraPFAOrg/LCPandoraAnalysis.git"
 
     tags = ["hep"]
 


### PR DESCRIPTION
## Summary
- update lccontent, larcontent, and LCPandoraAnalysis URLs to the PandoraPFAOrg GitHub organization
- retain the existing package versions and source locations

## Validation
- python3 -m py_compile for all three package recipes
- git diff --check
- confirmed the source archive URLs redirect successfully from GitHub