### PR TITLE
Support Ubuntu 24 in CVMFS release listings

### DIFF
--- a/.github/workflows/test-setup-scripts.yaml
+++ b/.github/workflows/test-setup-scripts.yaml
@@ -55,6 +55,8 @@ jobs:
         include:
           - os: alma9
             image: ghcr.io/key4hep/key4hep-images/alma9-cvmfs
+          - os: ubuntu24
+            image: ghcr.io/key4hep/key4hep-images/ubuntu24-cvmfs
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.image }}

--- a/scripts/cvmfs/setup-releases.sh
+++ b/scripts/cvmfs/setup-releases.sh
@@ -35,6 +35,8 @@ function list_releases() {
         name="centos7"
     elif [ "$os" = "ubuntu" ] || [ "$os" = "ubuntu22" ]; then
         name="ubuntu22"
+    elif [ "$os" = "ubuntu24" ]; then
+        name="ubuntu24"
     else
         echo "Unsupported OS, aborting..."
         usage
@@ -55,6 +57,8 @@ function list_packages() {
         name="almalinux9"
     elif [ "$os" = "ubuntu" ] || [ "$os" = "ubuntu22" ]; then
         name="ubuntu22"
+    elif [ "$os" = "ubuntu24" ]; then
+        name="ubuntu24"
     else
         echo "Unsupported OS, aborting..."
         usage


### PR DESCRIPTION
Fixes #900.

Use the real `ubuntu24` CVMFS release tree for Ubuntu 24 in both release and package listing paths. Add Ubuntu 24 coverage to the release setup CI matrix.

Tested with `ghcr.io/key4hep/key4hep-images/ubuntu24:latest` and a read-only CVMFS bind mount:
- release setup and `--list-releases`: passed; 2 Ubuntu 24 releases, including `2026-04-08`
- nightly setup and `--list-releases`: passed; 36 Ubuntu 24 nightlies