### PR TITLE
Allow nightly builds to build k4Reco after 0.5.0

### DIFF
--- a/packages/k4reco/package.py
+++ b/packages/k4reco/package.py
@@ -40,6 +40,8 @@ class K4reco(CMakePackage, Key4hepPackage):
     depends_on("k4fwcore@1.4:", when="@0.3.0:")
     depends_on("k4simgeant4")
     depends_on("root")
+    depends_on("fastjet", when="@0.5.0:")
+    depends_on("fjcontrib", when="@0.5.0:")
 
     depends_on("lcio", when="+conformal_tracking")
     depends_on("ilcutil", when="+conformal_tracking")


### PR DESCRIPTION
Add FastJet and fjcontrib as k4Reco dependencies after version 0.5.0 so nightly builds can resolve them.